### PR TITLE
Optimize capacity manager to use atomic SQL updates instead of row-level locks

### DIFF
--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDao.java
@@ -64,6 +64,7 @@ public interface CapacityDao extends GenericDao<CapacityVO, Long> {
 
     float findClusterConsumption(Long clusterId, short capacityType, long computeRequested);
 
+
     Pair<List<Long>, Map<Long, Double>> orderHostsByFreeCapacity(Long zoneId, Long clusterId, short capacityType);
 
     List<CapacityVO> listHostCapacityByCapacityTypes(Long zoneId, Long clusterId, List<Short> capacityTypes);
@@ -71,4 +72,16 @@ public interface CapacityDao extends GenericDao<CapacityVO, Long> {
     List<CapacityVO> listPodCapacityByCapacityTypes(Long zoneId, List<Short> capacityTypes);
 
     List<CapacityVO> listClusterCapacityByCapacityTypes(Long zoneId, Long podId, List<Short> capacityTypes);
+
+    void decrementUsedCapacity(long id, long amount);
+
+    void decrementReservedCapacity(long id, long amount);
+
+    void incrementUsedCapacity(long id, long amount);
+
+    void decrementUsedIncrementReservedCapacity(long id, long usedDecrement, long reservedIncrement, float overcommitRatio);
+
+    void decrementUsedIncrementReservedCapacity(long id, long usedDecrement, long reservedIncrement);
+
+    void incrementUsedDecrementReservedCapacity(long id, long usedIncrement, long reservedDecrement);
 }

--- a/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/capacity/dao/CapacityDaoImpl.java
@@ -55,6 +55,38 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
     private static final String SUBTRACT_ALLOCATED_SQL =
             "UPDATE `cloud`.`op_host_capacity` SET used_capacity = used_capacity - ? WHERE host_id = ? AND capacity_type = ?";
 
+    private static final String DECREMENT_USED_CAPACITY_SQL =
+            "UPDATE `cloud`.`op_host_capacity` SET " +
+            "used_capacity = CASE WHEN used_capacity >= ? THEN used_capacity - ? ELSE used_capacity END, " +
+            "update_time = NOW() WHERE id = ?";
+
+    private static final String DECREMENT_RESERVED_CAPACITY_SQL =
+            "UPDATE `cloud`.`op_host_capacity` SET " +
+            "reserved_capacity = CASE WHEN reserved_capacity >= ? THEN reserved_capacity - ? ELSE reserved_capacity END, " +
+            "update_time = NOW() WHERE id = ?";
+
+    private static final String INCREMENT_USED_CAPACITY_SQL =
+            "UPDATE `cloud`.`op_host_capacity` SET used_capacity = used_capacity + ?, " +
+            "update_time = NOW() WHERE id = ?";
+
+    private static final String DECREMENT_USED_INCREMENT_RESERVED_CAPPED_SQL =
+            "UPDATE `cloud`.`op_host_capacity` SET " +
+            "used_capacity = CASE WHEN used_capacity >= ? THEN used_capacity - ? ELSE used_capacity END, " +
+            "reserved_capacity = CASE WHEN reserved_capacity + ? <= CAST(total_capacity * ? AS SIGNED) " +
+            "THEN reserved_capacity + ? ELSE reserved_capacity END, " +
+            "update_time = NOW() WHERE id = ?";
+
+    private static final String DECREMENT_USED_INCREMENT_RESERVED_SQL =
+            "UPDATE `cloud`.`op_host_capacity` SET " +
+            "used_capacity = CASE WHEN used_capacity >= ? THEN used_capacity - ? ELSE used_capacity END, " +
+            "reserved_capacity = reserved_capacity + ?, " +
+            "update_time = NOW() WHERE id = ?";
+
+    private static final String INCREMENT_USED_DECREMENT_RESERVED_SQL =
+            "UPDATE `cloud`.`op_host_capacity` SET used_capacity = used_capacity + ?, " +
+            "reserved_capacity = GREATEST(reserved_capacity - ?, 0), " +
+            "update_time = NOW() WHERE id = ?";
+
     private static final String LIST_CLUSTERSINZONE_BY_HOST_CAPACITIES_PART1 =
             "SELECT DISTINCT capacity.cluster_id  FROM `cloud`.`op_host_capacity` capacity INNER JOIN `cloud`.`cluster` cluster on (cluster.id = capacity.cluster_id AND cluster.removed is NULL)   INNER JOIN `cloud`.`cluster_details` cluster_details ON (cluster.id = cluster_details.cluster_id ) WHERE ";
     private static final String LIST_CLUSTERSINZONE_BY_HOST_CAPACITIES_PART2 =
@@ -1289,6 +1321,93 @@ public class CapacityDaoImpl extends GenericDaoBase<CapacityVO, Long> implements
             logger.warn("Error checking cluster threshold", e);
         }
         return 0;
+    }
+
+    @Override
+    public void decrementUsedCapacity(long id, long amount) {
+        TransactionLegacy txn = TransactionLegacy.currentTxn();
+        try {
+            PreparedStatement pstmt = txn.prepareAutoCloseStatement(DECREMENT_USED_CAPACITY_SQL);
+            pstmt.setLong(1, amount);
+            pstmt.setLong(2, amount);
+            pstmt.setLong(3, id);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new CloudRuntimeException("Error decrementing used capacity for id: " + id, e);
+        }
+    }
+
+    @Override
+    public void decrementReservedCapacity(long id, long amount) {
+        TransactionLegacy txn = TransactionLegacy.currentTxn();
+        try {
+            PreparedStatement pstmt = txn.prepareAutoCloseStatement(DECREMENT_RESERVED_CAPACITY_SQL);
+            pstmt.setLong(1, amount);
+            pstmt.setLong(2, amount);
+            pstmt.setLong(3, id);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new CloudRuntimeException("Error decrementing reserved capacity for id: " + id, e);
+        }
+    }
+
+    @Override
+    public void incrementUsedCapacity(long id, long amount) {
+        TransactionLegacy txn = TransactionLegacy.currentTxn();
+        try {
+            PreparedStatement pstmt = txn.prepareAutoCloseStatement(INCREMENT_USED_CAPACITY_SQL);
+            pstmt.setLong(1, amount);
+            pstmt.setLong(2, id);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new CloudRuntimeException("Error incrementing used capacity for id: " + id, e);
+        }
+    }
+
+    @Override
+    public void decrementUsedIncrementReservedCapacity(long id, long usedDecrement, long reservedIncrement, float overcommitRatio) {
+        TransactionLegacy txn = TransactionLegacy.currentTxn();
+        try {
+            PreparedStatement pstmt = txn.prepareAutoCloseStatement(DECREMENT_USED_INCREMENT_RESERVED_CAPPED_SQL);
+            pstmt.setLong(1, usedDecrement);
+            pstmt.setLong(2, usedDecrement);
+            pstmt.setLong(3, reservedIncrement);
+            pstmt.setFloat(4, overcommitRatio);
+            pstmt.setLong(5, reservedIncrement);
+            pstmt.setLong(6, id);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new CloudRuntimeException("Error updating capacity (decrement used, increment reserved capped) for id: " + id, e);
+        }
+    }
+
+    @Override
+    public void decrementUsedIncrementReservedCapacity(long id, long usedDecrement, long reservedIncrement) {
+        TransactionLegacy txn = TransactionLegacy.currentTxn();
+        try {
+            PreparedStatement pstmt = txn.prepareAutoCloseStatement(DECREMENT_USED_INCREMENT_RESERVED_SQL);
+            pstmt.setLong(1, usedDecrement);
+            pstmt.setLong(2, usedDecrement);
+            pstmt.setLong(3, reservedIncrement);
+            pstmt.setLong(4, id);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new CloudRuntimeException("Error updating capacity (decrement used, increment reserved) for id: " + id, e);
+        }
+    }
+
+    @Override
+    public void incrementUsedDecrementReservedCapacity(long id, long usedIncrement, long reservedDecrement) {
+        TransactionLegacy txn = TransactionLegacy.currentTxn();
+        try {
+            PreparedStatement pstmt = txn.prepareAutoCloseStatement(INCREMENT_USED_DECREMENT_RESERVED_SQL);
+            pstmt.setLong(1, usedIncrement);
+            pstmt.setLong(2, reservedDecrement);
+            pstmt.setLong(3, id);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new CloudRuntimeException("Error updating capacity (increment used, decrement reserved) for id: " + id, e);
+        }
     }
 
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/resourcedetail/ResourceDetailsDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/resourcedetail/ResourceDetailsDao.java
@@ -98,6 +98,8 @@ public interface ResourceDetailsDao<R extends ResourceDetail> extends GenericDao
 
     Map<String, String> listDetailsKeyPairs(long resourceId, List<String> keys);
 
+    Map<Long, Map<String, String>> listDetailsKeyPairs(List<Long> resourceIds, List<String> keys);
+
     Map<String, String> listDetailsKeyPairs(long resourceId, boolean forDisplay);
 
     Map<String, Boolean> listDetailsVisibility(long resourceId);

--- a/engine/schema/src/main/java/org/apache/cloudstack/resourcedetail/ResourceDetailsDaoBase.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/resourcedetail/ResourceDetailsDaoBase.java
@@ -39,6 +39,7 @@ import org.apache.cloudstack.framework.config.impl.ConfigurationVO;
 import javax.inject.Inject;
 
 public abstract class ResourceDetailsDaoBase<R extends ResourceDetail> extends GenericDaoBase<R, Long> implements ResourceDetailsDao<R> {
+    private static final int IN_CLAUSE_BATCH_SIZE = 1000;
 
     @Inject
     private ConfigurationDao configDao;
@@ -120,6 +121,31 @@ public abstract class ResourceDetailsDaoBase<R extends ResourceDetail> extends G
 
         List<R> results = search(sc, null);
         return results.stream().collect(Collectors.toMap(R::getName, R::getValue));
+    }
+
+    @Override
+    public Map<Long, Map<String, String>> listDetailsKeyPairs(List<Long> resourceIds, List<String> keys) {
+        if (CollectionUtils.isEmpty(resourceIds)) {
+            return new HashMap<>();
+        }
+        SearchBuilder<R> sb = createSearchBuilder();
+        sb.and("resourceId", sb.entity().getResourceId(), SearchCriteria.Op.IN);
+        sb.and("name", sb.entity().getName(), SearchCriteria.Op.IN);
+        sb.done();
+
+        Map<Long, Map<String, String>> result = new HashMap<>(resourceIds.size());
+        for (int i = 0; i < resourceIds.size(); i += IN_CLAUSE_BATCH_SIZE) {
+            List<Long> batch = resourceIds.subList(i, Math.min(i + IN_CLAUSE_BATCH_SIZE, resourceIds.size()));
+            SearchCriteria<R> sc = sb.create();
+            sc.setParameters("resourceId", batch.toArray());
+            sc.setParameters("name", keys.toArray());
+            List<R> results = search(sc, null);
+            for (R r : results) {
+                result.computeIfAbsent(r.getResourceId(), k -> new HashMap<>())
+                        .put(r.getName(), r.getValue());
+            }
+        }
+        return result;
     }
 
     public Map<String, Boolean> listDetailsVisibility(long resourceId) {

--- a/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
@@ -19,6 +19,8 @@ package com.cloud.capacity;
 import static com.cloud.utils.NumbersUtil.toHumanReadableSize;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -668,13 +670,19 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         return serviceOfferingVO;
     }
 
+    private static final List<String> VM_DETAIL_KEYS_FOR_CAPACITY = List.of(
+            VmDetailConstants.CPU_OVER_COMMIT_RATIO,
+            VmDetailConstants.MEMORY_OVER_COMMIT_RATIO,
+            UsageEventVO.DynamicParameters.memory.name(),
+            UsageEventVO.DynamicParameters.cpuNumber.name(),
+            UsageEventVO.DynamicParameters.cpuSpeed.name());
+
     protected Map<String, String> getVmDetailsForCapacityCalculation(long vmId) {
-        return _vmInstanceDetailsDao.listDetailsKeyPairs(vmId,
-                List.of(VmDetailConstants.CPU_OVER_COMMIT_RATIO,
-                        VmDetailConstants.MEMORY_OVER_COMMIT_RATIO,
-                        UsageEventVO.DynamicParameters.memory.name(),
-                        UsageEventVO.DynamicParameters.cpuNumber.name(),
-                        UsageEventVO.DynamicParameters.cpuSpeed.name()));
+        return _vmInstanceDetailsDao.listDetailsKeyPairs(vmId, VM_DETAIL_KEYS_FOR_CAPACITY);
+    }
+
+    protected Map<Long, Map<String, String>> batchGetVmDetailsForCapacityCalculation(List<Long> vmIds) {
+        return _vmInstanceDetailsDao.listDetailsKeyPairs(vmIds, VM_DETAIL_KEYS_FOR_CAPACITY);
     }
 
     @DB
@@ -698,6 +706,21 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         logger.debug("Found {} VMs are Migrating from {}", vosMigrating.size(), host);
         vms.addAll(vosMigrating);
 
+
+        List<VMInstanceVO> vmsByLastHostId = _vmDao.listByLastHostId(host.getId());
+        logger.debug("Found {} VM, not running on {}", vmsByLastHostId.size(), host);
+
+        List<Long> allVmIds = new ArrayList<>(vms.size() + vmsByLastHostId.size());
+        for (VMInstanceVO vm : vms) {
+            allVmIds.add(vm.getId());
+        }
+        for (VMInstanceVO vm : vmsByLastHostId) {
+            allVmIds.add(vm.getId());
+        }
+        Map<Long, Map<String, String>> allVmDetails = allVmIds.isEmpty()
+                ? Collections.emptyMap()
+                : batchGetVmDetailsForCapacityCalculation(allVmIds);
+
         Pair<String, String> clusterValues =
                 clusterValuesCache.get(host.getClusterId());
         Float clusterCpuOvercommitRatio = Float.parseFloat(clusterValues.first());
@@ -705,7 +728,7 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         for (VMInstanceVO vm : vms) {
             Float cpuOvercommitRatio = 1.0f;
             Float ramOvercommitRatio = 1.0f;
-            Map<String, String> vmDetails = getVmDetailsForCapacityCalculation(vm.getId());
+            Map<String, String> vmDetails = allVmDetails.getOrDefault(vm.getId(), Collections.emptyMap());
             String vmDetailCpu = vmDetails.get(VmDetailConstants.CPU_OVER_COMMIT_RATIO);
             String vmDetailRam = vmDetails.get(VmDetailConstants.MEMORY_OVER_COMMIT_RATIO);
             // if vmDetailCpu or vmDetailRam is not null it means it is running in a overcommitted cluster.
@@ -736,16 +759,13 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
             }
         }
 
-        List<VMInstanceVO> vmsByLastHostId = _vmDao.listByLastHostId(host.getId());
-        logger.debug("Found {} VM, not running on {}", vmsByLastHostId.size(), host);
-
         for (VMInstanceVO vm : vmsByLastHostId) {
             Float cpuOvercommitRatio = 1.0f;
             Float ramOvercommitRatio = 1.0f;
             long lastModificationTime = Optional.ofNullable(vm.getUpdateTime()).orElse(vm.getCreated()).getTime();
             long secondsSinceLastUpdate = (DateUtil.currentGMTTime().getTime() - lastModificationTime) / 1000;
             if (secondsSinceLastUpdate < _vmCapacityReleaseInterval) {
-                Map<String, String> vmDetails = getVmDetailsForCapacityCalculation(vm.getId());
+                Map<String, String> vmDetails = allVmDetails.getOrDefault(vm.getId(), Collections.emptyMap());
                 String vmDetailCpu = vmDetails.get(VmDetailConstants.CPU_OVER_COMMIT_RATIO);
                 String vmDetailRam = vmDetails.get(VmDetailConstants.MEMORY_OVER_COMMIT_RATIO);
                 if (vmDetailCpu != null) {

--- a/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
+++ b/server/src/main/java/com/cloud/capacity/CapacityManagerImpl.java
@@ -200,94 +200,43 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         CapacityVO capacityCpu = _capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_CPU);
         CapacityVO capacityMemory = _capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_MEMORY);
         CapacityVO capacityCpuCore = _capacityDao.findByHostIdType(host.getId(), Capacity.CAPACITY_TYPE_CPU_CORE);
-        Long clusterId = host.getClusterId();
         if (capacityCpu == null || capacityMemory == null || svo == null || capacityCpuCore == null) {
             return false;
         }
 
         try {
-            final Long clusterIdFinal = clusterId;
-            final long capacityCpuId = capacityCpu.getId();
-            final long capacityMemoryId = capacityMemory.getId();
-            final long capacityCpuCoreId = capacityCpuCore.getId();
+            int vmCPU = svo.getCpu() * svo.getSpeed();
+            int vmCPUCore = svo.getCpu();
+            long vmMem = svo.getRamSize() * 1024L * 1024L;
+            long capacityCpuId = capacityCpu.getId();
+            long capacityMemoryId = capacityMemory.getId();
+            long capacityCpuCoreId = capacityCpuCore.getId();
 
-            Transaction.execute(new TransactionCallbackNoReturn() {
-                @Override
-                public void doInTransactionWithoutResult(TransactionStatus status) {
-                    CapacityVO capacityCpu = _capacityDao.lockRow(capacityCpuId, true);
-                    CapacityVO capacityMemory = _capacityDao.lockRow(capacityMemoryId, true);
-                    CapacityVO capacityCpuCore = _capacityDao.lockRow(capacityCpuCoreId, true);
-
-                    long usedCpu = capacityCpu.getUsedCapacity();
-                    long usedMem = capacityMemory.getUsedCapacity();
-                    long usedCpuCore = capacityCpuCore.getUsedCapacity();
-                    long reservedCpu = capacityCpu.getReservedCapacity();
-                    long reservedMem = capacityMemory.getReservedCapacity();
-                    long reservedCpuCore = capacityCpuCore.getReservedCapacity();
-                    long actualTotalCpu = capacityCpu.getTotalCapacity();
-                    float cpuOvercommitRatio = Float.parseFloat(_clusterDetailsDao.findDetail(clusterIdFinal, VmDetailConstants.CPU_OVER_COMMIT_RATIO).getValue());
-                    float memoryOvercommitRatio = Float.parseFloat(_clusterDetailsDao.findDetail(clusterIdFinal, VmDetailConstants.MEMORY_OVER_COMMIT_RATIO).getValue());
-                    int vmCPU = svo.getCpu() * svo.getSpeed();
-                    int vmCPUCore = svo.getCpu();
-                    long vmMem = svo.getRamSize() * 1024L * 1024L;
-                    long actualTotalMem = capacityMemory.getTotalCapacity();
-                    long totalMem = (long)(actualTotalMem * memoryOvercommitRatio);
-                    long totalCpu = (long)(actualTotalCpu * cpuOvercommitRatio);
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Hosts's actual total CPU: " + actualTotalCpu + " and CPU after applying overprovisioning: " + totalCpu);
-                        logger.debug("Hosts's actual total RAM: " + toHumanReadableSize(actualTotalMem) + " and RAM after applying overprovisioning: " + toHumanReadableSize(totalMem));
-                    }
-
-                    if (!moveFromReserved) {
-                        /* move resource from used */
-                        if (usedCpu >= vmCPU) {
-                            capacityCpu.setUsedCapacity(usedCpu - vmCPU);
-                        }
-                        if (usedMem >= vmMem) {
-                            capacityMemory.setUsedCapacity(usedMem - vmMem);
-                        }
-                        if (usedCpuCore >= vmCPUCore) {
-                            capacityCpuCore.setUsedCapacity(usedCpuCore - vmCPUCore);
-                        }
-
-                        if (moveToReservered) {
-                            if (reservedCpu + vmCPU <= totalCpu) {
-                                capacityCpu.setReservedCapacity(reservedCpu + vmCPU);
-                            }
-                            if (reservedMem + vmMem <= totalMem) {
-                                capacityMemory.setReservedCapacity(reservedMem + vmMem);
-                            }
-                            capacityCpuCore.setReservedCapacity(reservedCpuCore + vmCPUCore);
-                        }
-                    } else {
-                        if (reservedCpu >= vmCPU) {
-                            capacityCpu.setReservedCapacity(reservedCpu - vmCPU);
-                        }
-                        if (reservedMem >= vmMem) {
-                            capacityMemory.setReservedCapacity(reservedMem - vmMem);
-                        }
-                        if (reservedCpuCore >= vmCPUCore) {
-                            capacityCpuCore.setReservedCapacity(reservedCpuCore - vmCPUCore);
-                        }
-                    }
-
-                    logger.debug("release cpu from host: {}, old used: {}, " +
-                            "reserved: {}, actual total: {}, total with overprovisioning: {}; " +
-                            "new used: {},reserved:{}; movedfromreserved: {},moveToReservered: {}", host, usedCpu, reservedCpu, actualTotalCpu, totalCpu, capacityCpu.getUsedCapacity(), capacityCpu.getReservedCapacity(), moveFromReserved, moveToReservered);
-
-                    logger.debug("release mem from host: {}, old used: {}, " +
-                            "reserved: {}, total: {}; new used: {}, reserved: {}; " +
-                            "movedfromreserved: {}, moveToReservered: {}", host, toHumanReadableSize(usedMem), toHumanReadableSize(reservedMem), toHumanReadableSize(totalMem), toHumanReadableSize(capacityMemory.getUsedCapacity()), toHumanReadableSize(capacityMemory.getReservedCapacity()), moveFromReserved, moveToReservered);
-
-                    _capacityDao.update(capacityCpu.getId(), capacityCpu);
-                    _capacityDao.update(capacityMemory.getId(), capacityMemory);
-                    _capacityDao.update(capacityCpuCore.getId(), capacityCpuCore);
+            if (!moveFromReserved) {
+                if (moveToReservered) {
+                    float cpuOvercommitRatio = Float.parseFloat(_clusterDetailsDao.findDetail(host.getClusterId(), VmDetailConstants.CPU_OVER_COMMIT_RATIO).getValue());
+                    float memoryOvercommitRatio = Float.parseFloat(_clusterDetailsDao.findDetail(host.getClusterId(), VmDetailConstants.MEMORY_OVER_COMMIT_RATIO).getValue());
+                    _capacityDao.decrementUsedIncrementReservedCapacity(capacityCpuId, vmCPU, vmCPU, cpuOvercommitRatio);
+                    _capacityDao.decrementUsedIncrementReservedCapacity(capacityMemoryId, vmMem, vmMem, memoryOvercommitRatio);
+                    _capacityDao.decrementUsedIncrementReservedCapacity(capacityCpuCoreId, vmCPUCore, vmCPUCore);
+                } else {
+                    _capacityDao.decrementUsedCapacity(capacityCpuId, vmCPU);
+                    _capacityDao.decrementUsedCapacity(capacityMemoryId, vmMem);
+                    _capacityDao.decrementUsedCapacity(capacityCpuCoreId, vmCPUCore);
                 }
-            });
+            } else {
+                _capacityDao.decrementReservedCapacity(capacityCpuId, vmCPU);
+                _capacityDao.decrementReservedCapacity(capacityMemoryId, vmMem);
+                _capacityDao.decrementReservedCapacity(capacityCpuCoreId, vmCPUCore);
+            }
+
+            logger.debug(String.format("Released capacity from host: %s for VM: %s, " +
+                    "vmCPU: %d, vmMem: %s, vmCPUCore: %d, moveFromReserved: %s, moveToReserved: %s",
+                    host, vm, vmCPU, toHumanReadableSize(vmMem), vmCPUCore, moveFromReserved, moveToReservered));
 
             return true;
         } catch (Exception e) {
-            logger.debug("Failed to transit vm's state, due to " + e.getMessage());
+            logger.debug("Failed to release vm capacity, due to " + e.getMessage());
             return false;
         }
     }
@@ -321,106 +270,34 @@ public class CapacityManagerImpl extends ManagerBase implements CapacityManager,
         final long ram = svo.getRamSize() * 1024L * 1024L;
 
         try {
-            final long capacityCpuId = capacityCpu.getId();
-            final long capacityMemId = capacityMem.getId();
-            final long capacityCpuCoreId = capacityCpuCore.getId();
+            boolean hostHasCpuCapability = checkIfHostHasCpuCapability(host, cpucore, cpuspeed);
+            boolean hostHasCapacity = false;
 
-            Transaction.execute(new TransactionCallbackNoReturn() {
-                @Override
-                public void doInTransactionWithoutResult(TransactionStatus status) {
-                    CapacityVO capacityCpu = _capacityDao.lockRow(capacityCpuId, true);
-                    CapacityVO capacityMem = _capacityDao.lockRow(capacityMemId, true);
-                    CapacityVO capacityCpuCore = _capacityDao.lockRow(capacityCpuCoreId, true);
+            if (hostHasCpuCapability) {
+                hostHasCapacity = checkIfHostHasCapacity(host, cpu, ram, true, cpuOvercommitRatio, memoryOvercommitRatio, true);
+                if (!hostHasCapacity)
+                    hostHasCapacity = checkIfHostHasCapacity(host, cpu, ram, false, cpuOvercommitRatio, memoryOvercommitRatio, true);
+            }
 
-                    long usedCpu = capacityCpu.getUsedCapacity();
-                    long usedMem = capacityMem.getUsedCapacity();
-                    long usedCpuCore = capacityCpuCore.getUsedCapacity();
-                    long reservedCpu = capacityCpu.getReservedCapacity();
-                    long reservedMem = capacityMem.getReservedCapacity();
-                    long reservedCpuCore = capacityCpuCore.getReservedCapacity();
-                    long actualTotalCpu = capacityCpu.getTotalCapacity();
-                    long actualTotalMem = capacityMem.getTotalCapacity();
-                    long totalCpu = (long)(actualTotalCpu * cpuOvercommitRatio);
-                    long totalMem = (long)(actualTotalMem * memoryOvercommitRatio);
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Hosts's actual total CPU: " + actualTotalCpu + " and CPU after applying overprovisioning: " + totalCpu);
-                    }
+            if (!hostHasCapacity || !hostHasCpuCapability) {
+                throw new CloudRuntimeException("Host does not have enough capacity for vm " + vm);
+            }
 
-                    long freeCpu = totalCpu - (reservedCpu + usedCpu);
-                    long freeMem = totalMem - (reservedMem + usedMem);
+            if (fromLastHost) {
+                logger.debug("Allocating VM to the last host, adjusting reserved capacity");
+                _capacityDao.incrementUsedDecrementReservedCapacity(capacityCpu.getId(), cpu, cpu);
+                _capacityDao.incrementUsedDecrementReservedCapacity(capacityMem.getId(), ram, ram);
+                _capacityDao.incrementUsedDecrementReservedCapacity(capacityCpuCore.getId(), cpucore, cpucore);
+            } else {
+                _capacityDao.incrementUsedCapacity(capacityCpu.getId(), cpu);
+                _capacityDao.incrementUsedCapacity(capacityMem.getId(), ram);
+                _capacityDao.incrementUsedCapacity(capacityCpuCore.getId(), cpucore);
+            }
 
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("We are allocating VM, increasing the used capacity of this host:{}", host);
-                        logger.debug("Current Used CPU: {} , Free CPU:{} ,Requested CPU: {}", usedCpu, freeCpu, cpu);
-                        logger.debug("Current Used RAM: {} , Free RAM:{} ,Requested RAM: {}", toHumanReadableSize(usedMem), toHumanReadableSize(freeMem), toHumanReadableSize(ram));
-                    }
-                    capacityCpu.setUsedCapacity(usedCpu + cpu);
-                    capacityMem.setUsedCapacity(usedMem + ram);
-                    capacityCpuCore.setUsedCapacity(usedCpuCore + cpucore);
+            logger.debug(String.format("Allocated capacity on host: %s for VM: %s, " +
+                    "cpu: %d, mem: %s, cpuCore: %d, fromLastHost: %s",
+                    host, vm, cpu, toHumanReadableSize(ram), cpucore, fromLastHost));
 
-                    if (fromLastHost) {
-                        /* alloc from reserved */
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("We are allocating VM to the last host again, so adjusting the reserved capacity if it is not less than required");
-                            logger.debug("Reserved CPU: " + reservedCpu + " , Requested CPU: " + cpu);
-                            logger.debug("Reserved RAM: " + toHumanReadableSize(reservedMem) + " , Requested RAM: " + toHumanReadableSize(ram));
-                        }
-                        if (reservedCpu >= cpu && reservedMem >= ram) {
-                            capacityCpu.setReservedCapacity(reservedCpu - cpu);
-                            capacityMem.setReservedCapacity(reservedMem - ram);
-                            capacityCpuCore.setReservedCapacity(reservedCpuCore - cpucore);
-                        }
-                    } else {
-                        /* alloc from free resource */
-                        if (!((reservedCpu + usedCpu + cpu <= totalCpu) && (reservedMem + usedMem + ram <= totalMem))) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Host doesn't seem to have enough free capacity, but increasing the used capacity anyways, " +
-                                    "since the VM is already starting on this host ");
-                            }
-                        }
-                    }
-
-                    logger.debug(String.format("CPU STATS after allocation: for host: %s, " +
-                                    "old used: %d, old reserved: %d, actual total: %d, " +
-                                    "total with overprovisioning: %d; new used: %d, reserved: %d; " +
-                                    "requested cpu: %d, alloc_from_last: %s",
-                            host, usedCpu, reservedCpu, actualTotalCpu, totalCpu,
-                            capacityCpu.getUsedCapacity(), capacityCpu.getReservedCapacity(), cpu, fromLastHost));
-
-                    logger.debug("RAM STATS after allocation: for host: {}, " +
-                            "old used: {}, old reserved: {}, total: {}; new used: {}, reserved: {}; " +
-                            "requested mem: {}, alloc_from_last: {}",
-                            host, toHumanReadableSize(usedMem), toHumanReadableSize(reservedMem),
-                            toHumanReadableSize(totalMem), toHumanReadableSize(capacityMem.getUsedCapacity()),
-                            toHumanReadableSize(capacityMem.getReservedCapacity()), toHumanReadableSize(ram), fromLastHost);
-
-                    long cluster_id = host.getClusterId();
-                    ClusterDetailsVO cluster_detail_cpu = _clusterDetailsDao.findDetail(cluster_id, VmDetailConstants.CPU_OVER_COMMIT_RATIO);
-                    ClusterDetailsVO cluster_detail_ram = _clusterDetailsDao.findDetail(cluster_id, VmDetailConstants.MEMORY_OVER_COMMIT_RATIO);
-                    Float cpuOvercommitRatio = Float.parseFloat(cluster_detail_cpu.getValue());
-                    Float memoryOvercommitRatio = Float.parseFloat(cluster_detail_ram.getValue());
-
-                    boolean hostHasCpuCapability, hostHasCapacity = false;
-                    hostHasCpuCapability = checkIfHostHasCpuCapability(host, cpucore, cpuspeed);
-
-                    if (hostHasCpuCapability) {
-                        // first check from reserved capacity
-                        hostHasCapacity = checkIfHostHasCapacity(host, cpu, ram, true, cpuOvercommitRatio, memoryOvercommitRatio, true);
-
-                        // if not reserved, check the free capacity
-                        if (!hostHasCapacity)
-                            hostHasCapacity = checkIfHostHasCapacity(host, cpu, ram, false, cpuOvercommitRatio, memoryOvercommitRatio, true);
-                    }
-
-                    if (!hostHasCapacity || !hostHasCpuCapability) {
-                        throw new CloudRuntimeException("Host does not have enough capacity for vm " + vm);
-                    }
-
-                    _capacityDao.update(capacityCpu.getId(), capacityCpu);
-                    _capacityDao.update(capacityMem.getId(), capacityMem);
-                    _capacityDao.update(capacityCpuCore.getId(), capacityCpuCore);
-                }
-            });
         } catch (Exception e) {
             logger.error("Exception allocating VM capacity", e);
             if (e instanceof CloudRuntimeException) {

--- a/server/src/test/java/com/cloud/capacity/CapacityManagerImplTest.java
+++ b/server/src/test/java/com/cloud/capacity/CapacityManagerImplTest.java
@@ -20,19 +20,23 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.cloudstack.utils.bytescale.ByteScaleUtils;
+import org.apache.cloudstack.utils.cache.LazyCache;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,13 +45,20 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.cloud.capacity.dao.CapacityDao;
 import com.cloud.dc.ClusterDetailsDao;
 import com.cloud.host.Host;
+import com.cloud.host.HostVO;
+import com.cloud.host.dao.HostDao;
 import com.cloud.offering.ServiceOffering;
 import com.cloud.service.ServiceOfferingVO;
 import com.cloud.service.dao.ServiceOfferingDao;
 import com.cloud.utils.Pair;
+import com.cloud.event.UsageEventVO;
+import com.cloud.resource.ResourceState;
+import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VmDetailConstants;
+import com.cloud.vm.dao.VMInstanceDao;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CapacityManagerImplTest {
@@ -55,6 +66,12 @@ public class CapacityManagerImplTest {
     ClusterDetailsDao clusterDetailsDao;
     @Mock
     ServiceOfferingDao serviceOfferingDao;
+    @Mock
+    CapacityDao capacityDao;
+    @Mock
+    HostDao hostDao;
+    @Mock
+    VMInstanceDao vmInstanceDao;
 
     @Spy
     @InjectMocks
@@ -64,6 +81,7 @@ public class CapacityManagerImplTest {
     private Host host;
     private ServiceOffering offering;
     private static final long CLUSTER_ID = 1L;
+    private static final long HOST_ID = 100L;
     private static final int OFFERING_CPU = 4;
     private static final int OFFERING_CPU_SPEED = 2000;
     private static final int OFFERING_MEMORY = 4096;
@@ -178,5 +196,94 @@ public class CapacityManagerImplTest {
         verify(capacityManager).checkIfHostHasCapacity(eq(host), eq(OFFERING_CPU * OFFERING_CPU_SPEED),
                 eq(ByteScaleUtils.mebibytesToBytes(OFFERING_MEMORY)),
                 eq(false), eq(cpuOvercommit), eq(memoryOvercommit), eq(false));
+    }
+
+    @Test
+    public void testUpdateCapacityForHostMixedStaticAndDynamic() throws Exception {
+        HostVO testHost = mock(HostVO.class);
+        when(testHost.getId()).thenReturn(HOST_ID);
+        when(testHost.getClusterId()).thenReturn(CLUSTER_ID);
+        when(testHost.getResourceState()).thenReturn(ResourceState.Enabled);
+        when(testHost.getCpus()).thenReturn(16);
+        when(testHost.getSpeed()).thenReturn(2000L);
+        when(testHost.getTotalMemory()).thenReturn(32L * 1024 * 1024 * 1024);
+
+        Pair<String, String> clusterOvercommit = new Pair<>("2.0", "1.5");
+        doReturn(clusterOvercommit).when(capacityManager).getClusterValues(CLUSTER_ID);
+        java.lang.reflect.Field cacheField = CapacityManagerImpl.class.getDeclaredField("clusterValuesCache");
+        cacheField.setAccessible(true);
+        cacheField.set(capacityManager, new LazyCache<>(128, 60, capacityManager::getClusterValues));
+
+        long staticVmId = 1L;
+        long dynamicVmId = 2L;
+        long staticOfferingId = 10L;
+        long dynamicOfferingId = 20L;
+
+        VMInstanceVO staticVm = mock(VMInstanceVO.class);
+        when(staticVm.getId()).thenReturn(staticVmId);
+        when(staticVm.getServiceOfferingId()).thenReturn(staticOfferingId);
+
+        VMInstanceVO dynamicVm = mock(VMInstanceVO.class);
+        when(dynamicVm.getId()).thenReturn(dynamicVmId);
+        when(dynamicVm.getServiceOfferingId()).thenReturn(dynamicOfferingId);
+
+        when(vmInstanceDao.listIdServiceOfferingForUpVmsByHostId(HOST_ID))
+                .thenReturn(new ArrayList<>(List.of(staticVm, dynamicVm)));
+        when(vmInstanceDao.listIdServiceOfferingForVmsMigratingFromHost(HOST_ID))
+                .thenReturn(Collections.emptyList());
+        when(vmInstanceDao.listByLastHostId(HOST_ID))
+                .thenReturn(Collections.emptyList());
+
+        ServiceOfferingVO staticOffering = mock(ServiceOfferingVO.class);
+        when(staticOffering.isDynamic()).thenReturn(false);
+        when(staticOffering.getCpu()).thenReturn(2);
+        when(staticOffering.getSpeed()).thenReturn(2000);
+        when(staticOffering.getRamSize()).thenReturn(2048);
+
+        ServiceOfferingVO dynamicOffering = mock(ServiceOfferingVO.class);
+        when(dynamicOffering.isDynamic()).thenReturn(true);
+
+        doReturn(staticOffering).when(capacityManager).getServiceOffering(staticOfferingId);
+        doReturn(dynamicOffering).when(capacityManager).getServiceOffering(dynamicOfferingId);
+
+        Map<Long, Map<String, String>> batchDetails = new HashMap<>();
+        batchDetails.put(staticVmId, Map.of(
+                VmDetailConstants.CPU_OVER_COMMIT_RATIO, "2.0",
+                VmDetailConstants.MEMORY_OVER_COMMIT_RATIO, "1.5"));
+        batchDetails.put(dynamicVmId, Map.of(
+                VmDetailConstants.CPU_OVER_COMMIT_RATIO, "2.0",
+                VmDetailConstants.MEMORY_OVER_COMMIT_RATIO, "1.5",
+                UsageEventVO.DynamicParameters.cpuNumber.name(), "4",
+                UsageEventVO.DynamicParameters.cpuSpeed.name(), "2500",
+                UsageEventVO.DynamicParameters.memory.name(), "4096"));
+        doReturn(batchDetails).when(capacityManager).batchGetVmDetailsForCapacityCalculation(anyList());
+
+        CapacityVO cpuCapVO = new CapacityVO(HOST_ID, 1L, 1L, CLUSTER_ID, 0, 16 * 2000L, Capacity.CAPACITY_TYPE_CPU);
+        cpuCapVO.setReservedCapacity(0);
+        CapacityVO memCapVO = new CapacityVO(HOST_ID, 1L, 1L, CLUSTER_ID, 0, 32L * 1024 * 1024 * 1024, Capacity.CAPACITY_TYPE_MEMORY);
+        memCapVO.setReservedCapacity(0);
+        CapacityVO cpuCoreCapVO = new CapacityVO(HOST_ID, 1L, 1L, CLUSTER_ID, 0, 16L, CapacityVO.CAPACITY_TYPE_CPU_CORE);
+        cpuCoreCapVO.setReservedCapacity(0);
+
+        when(capacityDao.listByHostIdTypes(eq(HOST_ID), anyList()))
+                .thenReturn(List.of(cpuCapVO, memCapVO, cpuCoreCapVO));
+        when(capacityDao.update(anyLong(), any(CapacityVO.class))).thenReturn(true);
+
+        capacityManager.updateCapacityForHost(testHost);
+
+        // static VM: cpu = (2 * 2000 / 2.0) * 2.0 = 4000, mem = (2048 * 1024 * 1024 / 1.5) * 1.5 = 2048MB
+        // dynamic VM: cpu = (4 * 2500 / 2.0) * 2.0 = 10000, mem = (4096 * 1024 * 1024 / 1.5) * 1.5 = 4096MB
+        long expectedUsedCpu = 4000 + 10000;
+        long expectedUsedMem = (2048L + 4096L) * 1024 * 1024;
+        long expectedUsedCpuCore = 2 + 4;
+
+        assertEquals(expectedUsedCpu, cpuCapVO.getUsedCapacity());
+        assertEquals(expectedUsedMem, memCapVO.getUsedCapacity());
+        assertEquals(expectedUsedCpuCore, cpuCoreCapVO.getUsedCapacity());
+        assertEquals(0, cpuCapVO.getReservedCapacity());
+        assertEquals(0, memCapVO.getReservedCapacity());
+
+        verify(capacityManager).batchGetVmDetailsForCapacityCalculation(anyList());
+        verify(capacityManager, never()).getVmDetailsForCapacityCalculation(anyLong());
     }
 }

--- a/server/src/test/java/com/cloud/capacity/CapacityManagerImplTest.java
+++ b/server/src/test/java/com/cloud/capacity/CapacityManagerImplTest.java
@@ -50,17 +50,17 @@ import org.mockito.junit.MockitoJUnitRunner;
 import com.cloud.capacity.dao.CapacityDao;
 import com.cloud.dc.ClusterDetailsDao;
 import com.cloud.dc.ClusterDetailsVO;
+import com.cloud.event.UsageEventVO;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.host.dao.HostDao;
 import com.cloud.offering.ServiceOffering;
+import com.cloud.resource.ResourceState;
 import com.cloud.service.ServiceOfferingVO;
 import com.cloud.service.dao.ServiceOfferingDao;
 import com.cloud.utils.Pair;
-import com.cloud.event.UsageEventVO;
-import com.cloud.resource.ResourceState;
-import com.cloud.vm.VMInstanceVO;
 import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.VMInstanceVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.dao.VMInstanceDao;
@@ -377,6 +377,7 @@ public class CapacityManagerImplTest {
         verify(capacityDao, never()).incrementUsedCapacity(anyLong(), anyLong());
         verify(capacityDao, never()).incrementUsedDecrementReservedCapacity(anyLong(), anyLong(), anyLong());
     }
+
     @Test
     public void testUpdateCapacityForHostMixedStaticAndDynamic() throws Exception {
         HostVO testHost = mock(HostVO.class);

--- a/server/src/test/java/com/cloud/capacity/CapacityManagerImplTest.java
+++ b/server/src/test/java/com/cloud/capacity/CapacityManagerImplTest.java
@@ -19,6 +19,8 @@ package com.cloud.capacity;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,6 +49,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloud.capacity.dao.CapacityDao;
 import com.cloud.dc.ClusterDetailsDao;
+import com.cloud.dc.ClusterDetailsVO;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.host.dao.HostDao;
@@ -57,6 +60,8 @@ import com.cloud.utils.Pair;
 import com.cloud.event.UsageEventVO;
 import com.cloud.resource.ResourceState;
 import com.cloud.vm.VMInstanceVO;
+import com.cloud.utils.exception.CloudRuntimeException;
+import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.dao.VMInstanceDao;
 
@@ -80,11 +85,24 @@ public class CapacityManagerImplTest {
 
     private Host host;
     private ServiceOffering offering;
+    private VirtualMachine vm;
+    private HostVO hostVO;
+    private ServiceOfferingVO svo;
+    private CapacityVO cpuCap;
+    private CapacityVO memCap;
+    private CapacityVO cpuCoreCap;
     private static final long CLUSTER_ID = 1L;
     private static final long HOST_ID = 100L;
     private static final int OFFERING_CPU = 4;
     private static final int OFFERING_CPU_SPEED = 2000;
     private static final int OFFERING_MEMORY = 4096;
+    private static final long VM_ID = 200L;
+    private static final long SERVICE_OFFERING_ID = 300L;
+    private static final long CAPACITY_CPU_ID = 10L;
+    private static final long CAPACITY_MEM_ID = 11L;
+    private static final long CAPACITY_CPUCORE_ID = 12L;
+    private static final String CPU_OVERCOMMIT = "2.0";
+    private static final String MEM_OVERCOMMIT = "1.5";
 
     @Before
     public void setUp() {
@@ -198,6 +216,167 @@ public class CapacityManagerImplTest {
                 eq(false), eq(cpuOvercommit), eq(memoryOvercommit), eq(false));
     }
 
+    private void setUpReleaseMocks() {
+        vm = mock(VirtualMachine.class);
+        when(vm.getId()).thenReturn(VM_ID);
+        when(vm.getServiceOfferingId()).thenReturn(SERVICE_OFFERING_ID);
+
+        hostVO = mock(HostVO.class);
+        when(hostVO.getId()).thenReturn(HOST_ID);
+        when(hostDao.findById(HOST_ID)).thenReturn(hostVO);
+
+        svo = mock(ServiceOfferingVO.class);
+        when(svo.getCpu()).thenReturn(OFFERING_CPU);
+        when(svo.getSpeed()).thenReturn(OFFERING_CPU_SPEED);
+        when(svo.getRamSize()).thenReturn(OFFERING_MEMORY);
+        when(serviceOfferingDao.findById(VM_ID, SERVICE_OFFERING_ID)).thenReturn(svo);
+
+        cpuCap = mock(CapacityVO.class);
+        when(cpuCap.getId()).thenReturn(CAPACITY_CPU_ID);
+        memCap = mock(CapacityVO.class);
+        when(memCap.getId()).thenReturn(CAPACITY_MEM_ID);
+        cpuCoreCap = mock(CapacityVO.class);
+        when(cpuCoreCap.getId()).thenReturn(CAPACITY_CPUCORE_ID);
+
+        when(capacityDao.findByHostIdType(HOST_ID, Capacity.CAPACITY_TYPE_CPU)).thenReturn(cpuCap);
+        when(capacityDao.findByHostIdType(HOST_ID, Capacity.CAPACITY_TYPE_MEMORY)).thenReturn(memCap);
+        when(capacityDao.findByHostIdType(HOST_ID, Capacity.CAPACITY_TYPE_CPU_CORE)).thenReturn(cpuCoreCap);
+    }
+
+    private void setUpAllocateMocks() {
+        setUpReleaseMocks();
+        when(vm.getHostId()).thenReturn(HOST_ID);
+        when(hostVO.getClusterId()).thenReturn(CLUSTER_ID);
+
+        ClusterDetailsVO cpuDetail = mock(ClusterDetailsVO.class);
+        when(cpuDetail.getValue()).thenReturn(CPU_OVERCOMMIT);
+        ClusterDetailsVO memDetail = mock(ClusterDetailsVO.class);
+        when(memDetail.getValue()).thenReturn(MEM_OVERCOMMIT);
+        when(clusterDetailsDao.findDetail(CLUSTER_ID, VmDetailConstants.CPU_OVER_COMMIT_RATIO)).thenReturn(cpuDetail);
+        when(clusterDetailsDao.findDetail(CLUSTER_ID, VmDetailConstants.MEMORY_OVER_COMMIT_RATIO)).thenReturn(memDetail);
+    }
+
+    @Test
+    public void testReleaseVmCapacityNullHostReturnsTrue() {
+        assertTrue(capacityManager.releaseVmCapacity(mock(VirtualMachine.class), false, false, (Long) null));
+    }
+
+    @Test
+    public void testReleaseVmCapacityNullCapacityReturnsFalse() {
+        vm = mock(VirtualMachine.class);
+        when(vm.getId()).thenReturn(VM_ID);
+        when(vm.getServiceOfferingId()).thenReturn(SERVICE_OFFERING_ID);
+        hostVO = mock(HostVO.class);
+        when(hostVO.getId()).thenReturn(HOST_ID);
+        when(hostDao.findById(HOST_ID)).thenReturn(hostVO);
+
+        assertFalse(capacityManager.releaseVmCapacity(vm, false, false, HOST_ID));
+    }
+
+    @Test
+    public void testReleaseVmCapacityDecrementUsed() {
+        setUpReleaseMocks();
+        int expectedCpu = OFFERING_CPU * OFFERING_CPU_SPEED;
+        long expectedMem = OFFERING_MEMORY * 1024L * 1024L;
+
+        assertTrue(capacityManager.releaseVmCapacity(vm, false, false, HOST_ID));
+
+        verify(capacityDao).decrementUsedCapacity(CAPACITY_CPU_ID, expectedCpu);
+        verify(capacityDao).decrementUsedCapacity(CAPACITY_MEM_ID, expectedMem);
+        verify(capacityDao).decrementUsedCapacity(CAPACITY_CPUCORE_ID, OFFERING_CPU);
+        verify(capacityDao, never()).lockRow(anyLong(), anyBoolean());
+    }
+
+    @Test
+    public void testReleaseVmCapacityDecrementUsedIncrementReserved() {
+        setUpReleaseMocks();
+        when(hostVO.getClusterId()).thenReturn(CLUSTER_ID);
+        ClusterDetailsVO cpuDetail = mock(ClusterDetailsVO.class);
+        when(cpuDetail.getValue()).thenReturn(CPU_OVERCOMMIT);
+        ClusterDetailsVO memDetail = mock(ClusterDetailsVO.class);
+        when(memDetail.getValue()).thenReturn(MEM_OVERCOMMIT);
+        when(clusterDetailsDao.findDetail(CLUSTER_ID, VmDetailConstants.CPU_OVER_COMMIT_RATIO)).thenReturn(cpuDetail);
+        when(clusterDetailsDao.findDetail(CLUSTER_ID, VmDetailConstants.MEMORY_OVER_COMMIT_RATIO)).thenReturn(memDetail);
+
+        int expectedCpu = OFFERING_CPU * OFFERING_CPU_SPEED;
+        long expectedMem = OFFERING_MEMORY * 1024L * 1024L;
+
+        assertTrue(capacityManager.releaseVmCapacity(vm, false, true, HOST_ID));
+
+        verify(capacityDao).decrementUsedIncrementReservedCapacity(CAPACITY_CPU_ID, expectedCpu, expectedCpu, Float.parseFloat(CPU_OVERCOMMIT));
+        verify(capacityDao).decrementUsedIncrementReservedCapacity(CAPACITY_MEM_ID, expectedMem, expectedMem, Float.parseFloat(MEM_OVERCOMMIT));
+        verify(capacityDao).decrementUsedIncrementReservedCapacity(CAPACITY_CPUCORE_ID, (long) OFFERING_CPU, (long) OFFERING_CPU);
+        verify(capacityDao, never()).lockRow(anyLong(), anyBoolean());
+    }
+
+    @Test
+    public void testReleaseVmCapacityDecrementReserved() {
+        setUpReleaseMocks();
+        int expectedCpu = OFFERING_CPU * OFFERING_CPU_SPEED;
+        long expectedMem = OFFERING_MEMORY * 1024L * 1024L;
+
+        assertTrue(capacityManager.releaseVmCapacity(vm, true, false, HOST_ID));
+
+        verify(capacityDao).decrementReservedCapacity(CAPACITY_CPU_ID, expectedCpu);
+        verify(capacityDao).decrementReservedCapacity(CAPACITY_MEM_ID, expectedMem);
+        verify(capacityDao).decrementReservedCapacity(CAPACITY_CPUCORE_ID, OFFERING_CPU);
+        verify(capacityDao, never()).lockRow(anyLong(), anyBoolean());
+    }
+
+    @Test
+    public void testAllocateVmCapacityNewHost() {
+        setUpAllocateMocks();
+        int expectedCpu = OFFERING_CPU * OFFERING_CPU_SPEED;
+        long expectedMem = OFFERING_MEMORY * 1024L * 1024L;
+
+        doReturn(true).when(capacityManager).checkIfHostHasCpuCapability(any(Host.class), any(Integer.class), any(Integer.class));
+        doReturn(true).when(capacityManager).checkIfHostHasCapacity(any(Host.class), any(Integer.class), anyLong(), anyBoolean(), anyFloat(), anyFloat(), anyBoolean());
+
+        capacityManager.allocateVmCapacity(vm, false);
+
+        verify(capacityDao).incrementUsedCapacity(CAPACITY_CPU_ID, expectedCpu);
+        verify(capacityDao).incrementUsedCapacity(CAPACITY_MEM_ID, expectedMem);
+        verify(capacityDao).incrementUsedCapacity(CAPACITY_CPUCORE_ID, OFFERING_CPU);
+        verify(capacityDao, never()).lockRow(anyLong(), anyBoolean());
+    }
+
+    @Test
+    public void testAllocateVmCapacityFromLastHost() {
+        setUpAllocateMocks();
+        int expectedCpu = OFFERING_CPU * OFFERING_CPU_SPEED;
+        long expectedMem = OFFERING_MEMORY * 1024L * 1024L;
+
+        doReturn(true).when(capacityManager).checkIfHostHasCpuCapability(any(Host.class), any(Integer.class), any(Integer.class));
+        doReturn(true).when(capacityManager).checkIfHostHasCapacity(any(Host.class), any(Integer.class), anyLong(), anyBoolean(), anyFloat(), anyFloat(), anyBoolean());
+
+        capacityManager.allocateVmCapacity(vm, true);
+
+        verify(capacityDao).incrementUsedDecrementReservedCapacity(CAPACITY_CPU_ID, expectedCpu, expectedCpu);
+        verify(capacityDao).incrementUsedDecrementReservedCapacity(CAPACITY_MEM_ID, expectedMem, expectedMem);
+        verify(capacityDao).incrementUsedDecrementReservedCapacity(CAPACITY_CPUCORE_ID, (long) OFFERING_CPU, (long) OFFERING_CPU);
+        verify(capacityDao, never()).lockRow(anyLong(), anyBoolean());
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void testAllocateVmCapacityInsufficientThrows() {
+        setUpAllocateMocks();
+
+        doReturn(true).when(capacityManager).checkIfHostHasCpuCapability(any(Host.class), any(Integer.class), any(Integer.class));
+        doReturn(false).when(capacityManager).checkIfHostHasCapacity(any(Host.class), any(Integer.class), anyLong(), anyBoolean(), anyFloat(), anyFloat(), anyBoolean());
+
+        capacityManager.allocateVmCapacity(vm, false);
+    }
+
+    @Test
+    public void testAllocateVmCapacityNullCapacityReturnsEarly() {
+        setUpAllocateMocks();
+        when(capacityDao.findByHostIdType(HOST_ID, Capacity.CAPACITY_TYPE_CPU)).thenReturn(null);
+
+        capacityManager.allocateVmCapacity(vm, false);
+
+        verify(capacityDao, never()).incrementUsedCapacity(anyLong(), anyLong());
+        verify(capacityDao, never()).incrementUsedDecrementReservedCapacity(anyLong(), anyLong(), anyLong());
+    }
     @Test
     public void testUpdateCapacityForHostMixedStaticAndDynamic() throws Exception {
         HostVO testHost = mock(HostVO.class);


### PR DESCRIPTION
### Description

The `op_host_capacity` table experiences severe lock contention during concurrent VM lifecycle operations. Slow query analysis shows:

- **25s average execution time** (99% lock wait, not query execution)
- **5,724 executions in 20 hours** across 3 management server nodes
- **3% failure rate** from `errno 1205` (InnoDB lock wait timeout exceeded)
- Query: `SELECT ... FROM op_host_capacity WHERE id = ? FOR UPDATE`

**Root cause:** `CapacityManagerImpl.releaseVmCapacity()` and `allocateVmCapacity()` use a lock-read-compute-write pattern via `GenericDaoBase.lockRow()`. Each VM operation acquires exclusive row locks on 3 capacity rows (CPU, Memory, CPU Core), then holds those locks while performing Java computation, querying `cluster_details` for overcommit ratios, logging, and validating — before finally committing. Any concurrent VM operation targeting the same host queues behind this entire sequence.

**Fix:** Replace the `lockRow()` + `Transaction.execute()` pattern with single-statement atomic SQL UPDATEs that push arithmetic to the database:

```sql
-- Example: decrement used capacity (was lockRow + Java subtract + update)
UPDATE op_host_capacity SET
  used_capacity = CASE WHEN used_capacity >= ? THEN used_capacity - ? ELSE used_capacity END,
  update_time = NOW()
WHERE id = ?
```

Six new atomic DAO methods cover all capacity mutation patterns:
- `decrementUsedCapacity` — VM stop/migrate away
- `decrementReservedCapacity` — release reserved (destroy/expunge)
- `incrementUsedCapacity` — VM start/migrate to
- `decrementUsedIncrementReservedCapacity(id, used, reserved, overcommitRatio)` — VM stop with reservation (capped at overcommitted total)
- `decrementUsedIncrementReservedCapacity(id, used, reserved)` — same, uncapped (for CPU core which has no overcommit)
- `incrementUsedDecrementReservedCapacity` — allocate from last host

**Lock duration reduction:** From seconds (full transaction span including cluster_details reads, Java math, logging) to microseconds (single UPDATE statement). InnoDB still acquires an implicit row lock for each UPDATE, but releases it immediately on statement completion. 

**Behavioral changes from original code:**

| Aspect | Before | After |
|---|---|---|
| Lock scope | 3 rows locked simultaneously in one transaction | 1 row at a time, independent autocommit |
| Negative capacity guard | Java `if (used >= amount)` — leaves value unchanged | SQL `CASE WHEN used >= ? THEN used - ? ELSE used END` — same semantics |
| `fromLastHost` reserved decrement | Cross-row check: only decrements all 3 if CPU AND Memory both have enough reserved | Per-row: each independently decrements with `GREATEST(reserved - ?, 0)` floor. Fixes a reserved capacity leak in the original where one insufficient resource blocked all three from being freed |
| Capacity validation in `allocateVmCapacity` | Validated inside lock after incrementing (rollback on failure) | Validated before atomic increment (same pre-update DB state check). Tiny race window — acceptable since capacity accounting is approximate and `updateCapacityForHost()` periodically recalibrates |
| Overcommit ratio reads | Inside lock (adds lock hold time) | Before update (no lock contention contribution) |

**Atomicity guarantees:**

The old code relied on explicit `SELECT ... FOR UPDATE` row locks held across a multi-statement transaction to ensure correctness. The new code relies on InnoDB's implicit row-level locking within single UPDATE statements. Both are correct, but the lock hold time differs by orders of magnitude.

**Before — explicit transaction locking:**
```
BEGIN
  SELECT ... FOR UPDATE  ← X lock acquired on row (blocks here if contended)
  -- lock held --
  Java: read used/reserved/total from locked row
  Java: query cluster_details table for overcommit ratios (extra DB round-trip while holding lock)
  Java: compute new capacity values
  Java: log debug statements
  Java: validate capacity
  UPDATE row 1 (CPU)
  UPDATE row 2 (Memory)
  UPDATE row 3 (CPU Core)
COMMIT                   ← X locks on all 3 rows released
```
Lock hold time: **seconds** (measured avg 25s in production). Three rows locked simultaneously for the entire transaction span. Concurrent VM ops on the same host queue behind this.

**After — single-statement atomic updates:**
```
-- All reads and computation done BEFORE any locks --
Java: query capacity rows (regular SELECT, no lock)
Java: query cluster_details for overcommit ratios
Java: validate capacity

UPDATE row 1 (CPU)      ← X lock acquired, UPDATE executes, autocommit releases lock
UPDATE row 2 (Memory)   ← X lock acquired, UPDATE executes, autocommit releases lock
UPDATE row 3 (CPU Core) ← X lock acquired, UPDATE executes, autocommit releases lock
```
Lock hold time per row: **microseconds** (single UPDATE statement). Each row locked independently for the minimum possible duration.

**How InnoDB guarantees correctness for concurrent updates:**

When two sessions concurrently issue `UPDATE op_host_capacity SET used_capacity = used_capacity + ? WHERE id = ?` on the same row:

1. Session A reaches the row first, acquires an exclusive (X) lock on the clustered index entry
2. Session B attempts to acquire the same X lock, enters InnoDB's lock wait queue
3. Session A's UPDATE completes and autocommits — X lock is released
4. Session B is granted the lock and reads the **latest committed value** of `used_capacity` (post-Session-A), then applies its own increment
5. Session B's UPDATE completes and autocommits

This is guaranteed by InnoDB's locking protocol: an UPDATE always reads the latest committed version of the row, not an MVCC snapshot. Both increments are correctly applied with no lost updates. This behavior is identical in MySQL (5.6+) and MariaDB (10.x+), which both use InnoDB as the default storage engine. All SQL constructs used (`GREATEST`, `CASE WHEN`, `CAST ... AS SIGNED`, `NOW()`) are supported since MySQL 4.0+.


**What changes and what is acceptable:**

1. **Single-row correctness (no change):** Each UPDATE is atomic and serialized by InnoDB's row lock. `used_capacity = used_capacity + ?` cannot lose updates, and `CASE WHEN used_capacity >= ? THEN used_capacity - ? ELSE used_capacity END` prevents negative values. Equivalent to the old Java guards (`if (usedCpu >= vmCPU)`).

2. **Cross-row atomicity (relaxed, acceptable):** The old code updated CPU, Memory, and CPU Core in a single transaction — all-or-nothing. The new code uses three independent autocommit statements. If a DB connection dies between UPDATE 1 and UPDATE 2, capacity state is temporarily inconsistent for that host. This is an extremely unlikely failure mode (requires connection loss between two statements milliseconds apart), and `updateCapacityForHost()` periodic recalibration self-heals any inconsistency by recomputing capacity from actual VM state.

3. **Capacity validation window (slightly wider, acceptable):** In `allocateVmCapacity`, the capacity check (`checkIfHostHasCapacity`) now runs before the atomic UPDATE rather than inside the locked transaction. Two VMs could both pass validation before either writes. However, this is the same semantic as the original code — the original also validated against pre-update DB state (the `checkIfHostHasCapacity` call performs its own `findByHostIdType` SELECT, which reads uncommitted-to-disk values since the `_capacityDao.update()` hasn't been called yet within the transaction). The validation window is slightly wider without locks, but capacity accounting is inherently approximate and `updateCapacityForHost()` recalibration is the safety net.

4. **`fromLastHost` reserved decrement (improved):** The old code had a cross-row invariant (`reservedCpu >= cpu && reservedMem >= ram`) gating all three decrements — if memory didn't have enough reserved, CPU reserved wasn't freed either, leaking reserved capacity until the next recalibration. The new per-row `GREATEST(reserved - ?, 0)` frees each resource independently. This is strictly more correct.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

9 new unit tests added to `CapacityManagerImplTest` (15 total, all pass):

- **`testReleaseVmCapacityNullHostReturnsTrue`** — null host guard clause
- **`testReleaseVmCapacityNullCapacityReturnsFalse`** — null capacity entry guard clause
- **`testReleaseVmCapacityDecrementUsed`** — verifies `decrementUsedCapacity` called for CPU/Memory/CPU Core with correct amounts when `moveFromReserved=false, moveToReserved=false`
- **`testReleaseVmCapacityDecrementUsedIncrementReserved`** — verifies capped variant called with overcommit ratio for CPU/Memory, uncapped variant for CPU Core when `moveToReserved=true`
- **`testReleaseVmCapacityDecrementReserved`** — verifies `decrementReservedCapacity` called when `moveFromReserved=true`
- **`testAllocateVmCapacityNewHost`** — verifies `incrementUsedCapacity` called for all three capacity types
- **`testAllocateVmCapacityFromLastHost`** — verifies `incrementUsedDecrementReservedCapacity` called for all three capacity types
- **`testAllocateVmCapacityInsufficientThrows`** — verifies `CloudRuntimeException` thrown when host lacks capacity
- **`testAllocateVmCapacityNullCapacityReturnsEarly`** — verifies no DAO mutation when capacity entries are null

All tests verify `lockRow` is **never** called, confirming the lock-free atomic path.

