### PR TITLE
configdrive: don't write empty network_data.json for non-ConfigDrive DHCP/DNS providers

### DIFF
--- a/engine/storage/configdrive/src/main/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
+++ b/engine/storage/configdrive/src/main/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilder.java
@@ -248,16 +248,24 @@ public class ConfigDriveBuilder {
      * First we generate a JSON object using {@link #getNetworkDataJsonObjectForNic(NicProfile, List)}, then we write it to a file called "network_data.json".
      */
     static void writeNetworkData(List<NicProfile> nics, Map<Long, List<Network.Service>> supportedServices, File openStackFolder) {
-        JsonObject finalNetworkData = new JsonObject();
-        if (needForGeneratingNetworkData(supportedServices)) {
-            for (NicProfile nic : nics) {
-                List<Network.Service> supportedService = supportedServices.get(nic.getId());
-                JsonObject networkData = getNetworkDataJsonObjectForNic(nic, supportedService);
+        if (!needForGeneratingNetworkData(supportedServices)) {
+            // No NIC has the ConfigDrive provider assigned for Dhcp/Dns, meaning some other provider
+            // (e.g. a VirtualRouter or a network extension) is responsible for handing out network
+            // config over the wire. Skip writing network_data.json altogether: writing an empty-but-
+            // present file here would make cloud-init's DataSourceConfigDrive believe explicit (empty)
+            // network config was supplied, suppressing its default per-NIC DHCP auto-configuration and
+            // leaving the guest NIC administratively down.
+            return;
+        }
 
-                mergeJsonArraysAndUpdateObject(finalNetworkData, networkData, "links", "id", "type");
-                mergeJsonArraysAndUpdateObject(finalNetworkData, networkData, "networks", "id", "type");
-                mergeJsonArraysAndUpdateObject(finalNetworkData, networkData, "services", "address", "type");
-            }
+        JsonObject finalNetworkData = new JsonObject();
+        for (NicProfile nic : nics) {
+            List<Network.Service> supportedService = supportedServices.get(nic.getId());
+            JsonObject networkData = getNetworkDataJsonObjectForNic(nic, supportedService);
+
+            mergeJsonArraysAndUpdateObject(finalNetworkData, networkData, "links", "id", "type");
+            mergeJsonArraysAndUpdateObject(finalNetworkData, networkData, "networks", "id", "type");
+            mergeJsonArraysAndUpdateObject(finalNetworkData, networkData, "services", "address", "type");
         }
 
         writeFile(openStackFolder, "network_data.json", finalNetworkData.toString());

--- a/engine/storage/configdrive/src/test/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
+++ b/engine/storage/configdrive/src/test/java/org/apache/cloudstack/storage/configdrive/ConfigDriveBuilderTest.java
@@ -644,19 +644,15 @@ public class ConfigDriveBuilderTest {
         folder.create();
         File openStackFolder = folder.newFolder("openStack");
 
-        // Expected JSON structure
-        String expectedJson = "{}";
-
         // Action
         ConfigDriveBuilder.writeNetworkData(Arrays.asList(nicp), supportedServices, openStackFolder);
 
-        // Verify
+        // Verify: no NIC has the ConfigDrive provider assigned for Dhcp/Dns, so network_data.json
+        // must not be written at all -- an empty-but-present file would make cloud-init believe
+        // explicit (empty) network config was supplied, suppressing its default DHCP auto-config
+        // and leaving the guest NIC administratively down.
         File networkDataFile = new File(openStackFolder, "network_data.json");
-        String content = FileUtils.readFileToString(networkDataFile, StandardCharsets.UTF_8);
-        JsonObject actualJson = new JsonParser().parse(content).getAsJsonObject();
-        JsonObject expectedJsonObject = new JsonParser().parse(expectedJson).getAsJsonObject();
-
-        Assert.assertEquals(expectedJsonObject, actualJson);
+        Assert.assertFalse(networkDataFile.exists());
         folder.delete();
     }
 }


### PR DESCRIPTION
### Description


ConfigDriveBuilder.writeNetworkData() unconditionally wrote network_data.json, even when needForGeneratingNetworkData() determined no NIC has the ConfigDrive NSP assigned as its Dhcp/Dns provider (e.g. networks using a VirtualRouter or a NetworkExtensionElement-based provider instead). Writing an empty-but-present file makes cloud-init's DataSourceConfigDrive believe explicit (empty) network config was supplied, which suppresses its default per-NIC DHCP auto-configuration and leaves the guest NIC administratively down with no DHCP request ever sent.

Skip writing the file entirely in that case, so cloud-init falls back to its default behavior of bringing up and DHCP-configuring all available NICs.


<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
