### PR TITLE
api: fix ProjectResponse.setVpcLimit assigning the network limit

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/ProjectResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ProjectResponse.java
@@ -362,7 +362,7 @@ public class ProjectResponse extends BaseResponse implements ResourceLimitAndCou
 
     @Override
     public void setVpcLimit(String vpcLimit) {
-        this.vpcLimit = networkLimit;
+        this.vpcLimit = vpcLimit;
     }
 
     @Override

--- a/api/src/test/java/org/apache/cloudstack/api/response/ProjectResponseTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/response/ProjectResponseTest.java
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.response;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ProjectResponseTest {
+
+    @Test
+    public void setVpcLimitStoresItsOwnParameterNotTheNetworkLimit() {
+        ProjectResponse response = new ProjectResponse();
+        response.setNetworkLimit("5");
+        response.setVpcLimit("10");
+
+        Assert.assertEquals("10", ReflectionTestUtils.getField(response, "vpcLimit"));
+        Assert.assertEquals("5", ReflectionTestUtils.getField(response, "networkLimit"));
+    }
+}


### PR DESCRIPTION
### Description

`ProjectResponse.setVpcLimit(String vpcLimit)` ignored its argument and assigned
the `networkLimit` field instead:

    public void setVpcLimit(String vpcLimit) {
        this.vpcLimit = networkLimit;   // should be vpcLimit
    }

**Actual behaviour:** `listProjects` reports a project's `vpclimit` equal to its
`networklimit` (and `null` if `setVpcLimit` runs before `setNetworkLimit`).
**Expected behaviour:** `vpclimit` reflects the project's real VPC limit,
independent of the network limit.

Every sibling setter in the class assigns its own parameter; this one was a
copy-paste slip. Fix: assign the `vpcLimit` parameter.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

- Added a unit test (`ProjectResponseTest`) asserting `setVpcLimit` stores its own
  value and leaves `networkLimit` untouched.
- Built standard `.deb` packages and deployed a KVM advanced zone; confirmed
  `listProjects` returns the correct, independent `vpclimit`.

#### How did you try to break this feature and the system with this change?

Set different network and VPC limits on a project and verified via `listProjects`
that `vpclimit` reflects the VPC limit — including when the VPC limit is set
before the network limit.