### PR TITLE
api: fix inverted value comparison in ImageStoreDetailResponse.equals

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/ImageStoreDetailResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/ImageStoreDetailResponse.java
@@ -16,6 +16,8 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
+import java.util.Objects;
+
 import com.google.gson.annotations.SerializedName;
 
 import org.apache.cloudstack.api.BaseResponse;
@@ -81,7 +83,7 @@ public class ImageStoreDetailResponse extends BaseResponse {
                 return false;
         } else if (!oid.equals(other.getName()))
             return false;
-        else if (this.getValue().equals(other.getValue()))
+        else if (!Objects.equals(this.getValue(), other.getValue()))
             return false;
         return true;
     }

--- a/api/src/test/java/org/apache/cloudstack/api/response/ImageStoreDetailResponseTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/response/ImageStoreDetailResponseTest.java
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.response;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ImageStoreDetailResponseTest {
+
+    @Test
+    public void equalsIsTrueForSameNameAndValue() {
+        ImageStoreDetailResponse a = new ImageStoreDetailResponse("key", "value");
+        ImageStoreDetailResponse b = new ImageStoreDetailResponse("key", "value");
+        Assert.assertEquals(a, b);
+        Assert.assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void equalsIsFalseWhenValueDiffers() {
+        ImageStoreDetailResponse a = new ImageStoreDetailResponse("key", "value");
+        ImageStoreDetailResponse c = new ImageStoreDetailResponse("key", "other");
+        Assert.assertNotEquals(a, c);
+    }
+
+    @Test
+    public void equalsIsFalseWhenNameDiffers() {
+        ImageStoreDetailResponse a = new ImageStoreDetailResponse("key", "value");
+        ImageStoreDetailResponse d = new ImageStoreDetailResponse("other", "value");
+        Assert.assertNotEquals(a, d);
+    }
+}


### PR DESCRIPTION
### Description

`ImageStoreDetailResponse.equals()` had the value comparison inverted - it
returned `false` when the two responses had the **same** value and `true` when
the values **differed**:

    else if (this.getValue().equals(other.getValue()))
        return false;

So two identical details were treated as unequal, and two details differing only
by value were treated as equal — which corrupts any Set/Map/dedup keyed on
`ImageStoreDetailResponse`. It also threw an NPE when the value was null.

Fixed by comparing with `!Objects.equals(getValue(), other.getValue())`, which
restores the correct result and is null-safe.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [x] Minor

### How Has This Been Tested?

Added unit tests covering equal name+value, differing value, and differing name.
Also built the standard packages and deployed on a KVM advanced zone.