### PR TITLE
server: apply the restored volume max IOPS to the max IOPS field

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -8665,7 +8665,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                     resizedVolume.setMinIops(Long.parseLong(minIops));
                 }
                 if (StringUtils.isNumeric(maxIops)) {
-                    resizedVolume.setMinIops(Long.parseLong(maxIops));
+                    resizedVolume.setMaxIops(Long.parseLong(maxIops));
                 }
             }
         }

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -3207,4 +3207,19 @@ public class UserVmManagerImplTest {
                 userVmManagerImpl.verifyVmLimits(userVmVoMock, customParameters));
         Assert.assertTrue(ex.getMessage().startsWith("The CPU speed of this offering"));
     }
+
+    @Test
+    public void getRootVolumeSizeForVmRestoreAppliesMaxIopsToTheMaxIopsField() {
+        VolumeVO volume = new VolumeVO(Volume.Type.ROOT, "root", 1L, 1L, 1L, 1L,
+                com.cloud.storage.Storage.ProvisioningType.THIN, 10L, null, null, null);
+        UserVmVO restoreVm = Mockito.mock(UserVmVO.class);
+        Map<String, String> details = new HashMap<>();
+        details.put(ApiConstants.MIN_IOPS, "500");
+        details.put(ApiConstants.MAX_IOPS, "2000");
+
+        userVmManagerImpl.getRootVolumeSizeForVmRestore(volume, null, restoreVm, null, details, true);
+
+        Assert.assertEquals(Long.valueOf(500L), volume.getMinIops());
+        Assert.assertEquals(Long.valueOf(2000L), volume.getMaxIops());
+    }
 }


### PR DESCRIPTION
### Description

When a VM is restored, `getRootVolumeSizeForVmRestore` reads the requested min
and max IOPS from the volume details, but a copy-paste slip assigned the max
IOPS value into the min IOPS field:

    if (StringUtils.isNumeric(maxIops)) {
        resizedVolume.setMinIops(Long.parseLong(maxIops));
    }

So `setMinIops` was called twice and `setMaxIops` was never called. The result
is that restoring a VM silently drops the volume's max IOPS QoS setting and
overwrites min IOPS with the max value. Fixed by assigning the parsed max IOPS
to `setMaxIops`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [x] Minor

### How Has This Been Tested?

Added a unit test that restores a volume with min IOPS 500 and max IOPS 2000
and asserts each field holds its own value. Also built the standard packages
and deployed on a KVM advanced zone.