### PR TITLE
server: null-check requested IP in assignSourceNatPublicIpAddress

### DIFF
--- a/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -828,7 +828,7 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
         if(networkPublicIp != null)
             return null;
         IPAddressVO ipAddressVO = _ipAddressDao.findByIpAndDcId(dcId, requestedIp);
-        if (ipAddressVO.getState() != State.Free) {
+        if (ipAddressVO == null || ipAddressVO.getState() != State.Free) {
             throw new InsufficientAddressCapacityException("can not assign to this network", Network.class, networkId);
         }
         return fetchNewPublicIp(dcId, podId, null, owner, type, networkId, true, true, requestedIp, null, isSystem, null, null, forSystemVms);

--- a/server/src/test/java/com/cloud/network/IpAddressManagerImplSourceNatTest.java
+++ b/server/src/test/java/com/cloud/network/IpAddressManagerImplSourceNatTest.java
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.network;
+
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloud.dc.Vlan.VlanType;
+import com.cloud.exception.InsufficientAddressCapacityException;
+import com.cloud.network.dao.IPAddressDao;
+import com.cloud.user.Account;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IpAddressManagerImplSourceNatTest {
+
+    @Mock
+    private IPAddressDao _ipAddressDao;
+
+    @InjectMocks
+    private IpAddressManagerImpl ipAddressManagerImpl = new IpAddressManagerImpl();
+
+    @Test(expected = InsufficientAddressCapacityException.class)
+    public void assignSourceNatPublicIpAddressThrowsWhenRequestedIpNotFound() throws Exception {
+        // findByIpAndDcId returns null when the requested IP is not a known
+        // public IP in the zone. The method must throw a capacity exception
+        // rather than dereference the null IPAddressVO with getState().
+        long dcId = 1L;
+        long networkId = 2L;
+        String requestedIp = "10.1.1.1";
+        Account owner = Mockito.mock(Account.class);
+
+        when(_ipAddressDao.findByIpAndNetworkIdAndDcId(networkId, dcId, requestedIp)).thenReturn(null);
+        when(_ipAddressDao.findByIpAndDcId(dcId, requestedIp)).thenReturn(null);
+
+        ipAddressManagerImpl.assignSourceNatPublicIpAddress(dcId, null, owner, VlanType.VirtualNetwork,
+                networkId, requestedIp, false, false);
+    }
+}


### PR DESCRIPTION
### Description

`assignSourceNatPublicIpAddress` looks up the requested IP with
`findByIpAndDcId` and then reads its state:

    IPAddressVO ipAddressVO = _ipAddressDao.findByIpAndDcId(dcId, requestedIp);
    if (ipAddressVO.getState() != State.Free) {

`findByIpAndDcId` returns null when the requested IP is not a known public IP in
the zone, so this throws a NullPointerException instead of a meaningful error.
Fixed by null-checking the result first, so the method throws the intended
`InsufficientAddressCapacityException` when the IP cannot be found.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [x] Minor

### How Has This Been Tested?

Added a unit test that requests a source NAT IP not present in the zone and
asserts an InsufficientAddressCapacityException is thrown instead of an NPE.
Also built the standard packages and deployed on a KVM advanced zone.