### PR TITLE
server: null-check public IP before the DNS/Source NAT guard in create

### DIFF
--- a/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/lb/LoadBalancingRulesManagerImpl.java
@@ -1706,7 +1706,7 @@ public class LoadBalancingRulesManagerImpl<Type> extends ManagerBase implements 
         IpAddress systemIp = null;
         NetworkOffering off = _entityMgr.findById(NetworkOffering.class, network.getNetworkOfferingId());
 
-        if (srcPortStart == DNS_PORT && ipVO.isSourceNat()) {
+        if (srcPortStart == DNS_PORT && ipVO != null && ipVO.isSourceNat()) {
             List<NetworkOfferingServiceMapVO> offeringServices = _networkOfferingServiceDao.listByNetworkOfferingId(network.getNetworkOfferingId());
             for (NetworkOfferingServiceMapVO serviceMapVo: offeringServices) {
                 if (serviceMapVo.getService().equals(Service.Dns.getName())) {

--- a/server/src/test/java/com/cloud/network/lb/LoadBalancingRulesManagerImplTest.java
+++ b/server/src/test/java/com/cloud/network/lb/LoadBalancingRulesManagerImplTest.java
@@ -17,10 +17,16 @@
 
 package com.cloud.network.lb;
 
+import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.network.Network;
+import com.cloud.network.NetworkModel;
 import com.cloud.network.dao.LoadBalancerVO;
 import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkVO;
+import com.cloud.offering.NetworkOffering;
+import com.cloud.user.Account;
+import com.cloud.user.AccountManager;
+import com.cloud.utils.db.EntityManager;
 import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationService;
@@ -47,6 +53,21 @@ public class LoadBalancingRulesManagerImplTest{
 
     @Mock
     NetworkOrchestrationService _networkMgr;
+
+    @Mock
+    EntityManager _entityMgr;
+
+    @Mock
+    AccountManager _accountMgr;
+
+    @Mock
+    NetworkModel _networkModel;
+
+    @Mock
+    NetworkVO networkMock;
+
+    private long accountId = 10L;
+    private long networkId = 4L;
 
     @Spy
     @InjectMocks
@@ -100,5 +121,20 @@ public class LoadBalancingRulesManagerImplTest{
         when(_networkMgr.getProvidersForServiceInNetwork(networkMock, Network.Service.Lb)).thenReturn(new ArrayList<>());
 
         Network.Provider provider = lbr.getLoadBalancerServiceProvider(loadBalancerMock);
+    }
+
+    @Test(expected = InvalidParameterValueException.class)
+    public void createPublicLoadBalancerRuleWithDnsPortAndNoIpDoesNotNpe() throws Exception {
+        long lbOwnerId = accountId;
+        long networkOfferingId = 7L;
+        when(_accountMgr.getAccount(lbOwnerId)).thenReturn(Mockito.mock(Account.class));
+        when(_networkModel.getNetwork(networkId)).thenReturn(networkMock);
+        when(networkMock.getNetworkOfferingId()).thenReturn(networkOfferingId);
+        NetworkOffering off = Mockito.mock(NetworkOffering.class);
+        when(_entityMgr.findById(NetworkOffering.class, networkOfferingId)).thenReturn(off);
+        when(off.isElasticLb()).thenReturn(false);
+
+        lbr.createPublicLoadBalancerRule("xid", "name", "desc", 53, 53, 53, 53,
+                null, "tcp", "roundrobin", networkId, lbOwnerId, false, "tcp", null, null);
     }
 }


### PR DESCRIPTION
Description
### Description

`createPublicLoadBalancerRule` guards a special case for the DNS port before it
has resolved the public IP:

    if (srcPortStart == DNS_PORT && ipVO.isSourceNat()) {

When the caller does not pass an explicit IP (`ipAddrId` is null), `ipVO` is null
at this point, so creating a load balancer rule on the DNS port throws a
NullPointerException instead of the normal validation error. Fixed by
null-checking `ipVO` before calling `isSourceNat()`, so the DNS/Source NAT branch
is skipped when there is no IP and the flow reaches the intended parameter
validation.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [x] Minor

### How Has This Been Tested?

Added a unit test that creates a public load balancer rule on the DNS port with
no explicit IP and asserts it fails with a parameter validation error instead of
a NullPointerException. Also built the standard packages and deployed on a KVM
advanced zone.