### PR TITLE
framework: do not double-execute an async job after returning its queue item

### DIFF
--- a/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -703,57 +703,56 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
 
     protected void executeQueueItem(SyncQueueItemVO item, boolean fromPreviousSession) {
         AsyncJobVO job = _jobDao.findById(item.getContentId());
-        if (job != null) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Schedule queued job-" + job.getId());
-            }
-
-            job.setSyncSource(item);
-
-            //
-            // TODO: a temporary solution to work-around DB deadlock situation
-            //
-            // to live with DB deadlocks, we will give a chance for job to be rescheduled
-            // in case of exceptions (most-likely DB deadlock exceptions)
-            try {
-                job.setExecutingMsid(getMsid());
-                _jobDao.update(job.getId(), job);
-            } catch (Exception e) {
-                logger.warn("Unexpected exception while dispatching job-" + item.getContentId(), e);
-
-                try {
-                    _queueMgr.returnItem(item.getId());
-                } catch (Throwable thr) {
-                    logger.error("Unexpected exception while returning job-" + item.getContentId() + " to queue", thr);
-                }
-                return;
-            }
-
-            try {
-                scheduleExecution(job);
-            } catch (RejectedExecutionException e) {
-                logger.warn("Execution for job-" + job.getId() + " is rejected, return it to the queue for next turn");
-
-                try {
-                    _queueMgr.returnItem(item.getId());
-                } catch (Exception e2) {
-                    logger.error("Unexpected exception while returning job-" + item.getContentId() + " to queue", e2);
-                }
-
-                try {
-                    job.setExecutingMsid(null);
-                    _jobDao.update(job.getId(), job);
-                } catch (Exception e3) {
-                    logger.warn("Unexpected exception while update job-" + item.getContentId() + " msid for bookkeeping");
-                }
-            }
-
-        } else {
+        if (job == null) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Unable to find related job for queue item: " + item.toString());
             }
-
             _queueMgr.purgeItem(item.getId());
+            return;
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Schedule queued job-" + job.getId());
+        }
+        job.setSyncSource(item);
+
+        //
+        // TODO: a temporary solution to work-around DB deadlock situation
+        //
+        // to live with DB deadlocks, we will give a chance for job to be rescheduled
+        // in case of exceptions (most-likely DB deadlock exceptions)
+        try {
+            job.setExecutingMsid(getMsid());
+            _jobDao.update(job.getId(), job);
+        } catch (Exception e) {
+            logger.warn("Unexpected exception while dispatching job-" + item.getContentId(), e);
+            returnItemToQueue(item);
+            return;
+        }
+
+        try {
+            scheduleExecution(job);
+        } catch (RejectedExecutionException e) {
+            logger.warn("Execution for job-" + job.getId() + " is rejected, return it to the queue for next turn");
+            returnItemToQueue(item);
+            clearExecutingMsid(job, item);
+        }
+    }
+
+    private void returnItemToQueue(SyncQueueItemVO item) {
+        try {
+            _queueMgr.returnItem(item.getId());
+        } catch (Throwable thr) {
+            logger.error("Unexpected exception while returning job-" + item.getContentId() + " to queue", thr);
+        }
+    }
+
+    private void clearExecutingMsid(AsyncJobVO job, SyncQueueItemVO item) {
+        try {
+            job.setExecutingMsid(null);
+            _jobDao.update(job.getId(), job);
+        } catch (Exception e) {
+            logger.warn("Unexpected exception while update job-" + item.getContentId() + " msid for bookkeeping");
         }
     }
 

--- a/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -523,7 +523,7 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
         return StringUtils.obfuscatePasswordInJsonLikeString(result);
     }
 
-    private void scheduleExecution(final AsyncJobVO job) {
+    protected void scheduleExecution(final AsyncJobVO job) {
         scheduleExecution(job, false);
     }
 
@@ -701,7 +701,7 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
         return signals;
     }
 
-    private void executeQueueItem(SyncQueueItemVO item, boolean fromPreviousSession) {
+    protected void executeQueueItem(SyncQueueItemVO item, boolean fromPreviousSession) {
         AsyncJobVO job = _jobDao.findById(item.getContentId());
         if (job != null) {
             if (logger.isDebugEnabled()) {
@@ -726,6 +726,7 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
                 } catch (Throwable thr) {
                     logger.error("Unexpected exception while returning job-" + item.getContentId() + " to queue", thr);
                 }
+                return;
             }
 
             try {

--- a/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
+++ b/framework/jobs/src/main/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImpl.java
@@ -701,6 +701,15 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
         return signals;
     }
 
+    /**
+     * Dispatches the job behind a sync queue item.
+     * <p>
+     * TODO: stamping the executing management server id on the job can hit a DB deadlock. As a
+     * temporary workaround, a failed update returns the item to the sync queue so the job is retried
+     * on a later turn instead of failing. The proper fix is to remove the deadlock at its source, in
+     * the locking and transaction around the sync_queue and async_job updates on dispatch, after
+     * which this retry is no longer needed.
+     */
     protected void executeQueueItem(SyncQueueItemVO item, boolean fromPreviousSession) {
         AsyncJobVO job = _jobDao.findById(item.getContentId());
         if (job == null) {
@@ -716,11 +725,6 @@ public class AsyncJobManagerImpl extends ManagerBase implements AsyncJobManager,
         }
         job.setSyncSource(item);
 
-        //
-        // TODO: a temporary solution to work-around DB deadlock situation
-        //
-        // to live with DB deadlocks, we will give a chance for job to be rescheduled
-        // in case of exceptions (most-likely DB deadlock exceptions)
         try {
             job.setExecutingMsid(getMsid());
             _jobDao.update(job.getId(), job);

--- a/framework/jobs/src/test/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImplExecuteQueueItemTest.java
+++ b/framework/jobs/src/test/java/org/apache/cloudstack/framework/jobs/impl/AsyncJobManagerImplExecuteQueueItemTest.java
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.framework.jobs.impl;
+
+import org.apache.cloudstack.framework.jobs.dao.AsyncJobDao;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloud.utils.exception.CloudRuntimeException;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class AsyncJobManagerImplExecuteQueueItemTest {
+
+    @Mock
+    AsyncJobDao _jobDao;
+    @Mock
+    SyncQueueManager _queueMgr;
+
+    @Spy
+    @InjectMocks
+    AsyncJobManagerImpl asyncJobManager = new AsyncJobManagerImpl();
+
+    @Test
+    public void executeQueueItemDoesNotScheduleWhenTheJobUpdateFailsAndItemIsReturned() {
+        long contentId = 10L;
+        long itemId = 20L;
+        long jobId = 1L;
+
+        SyncQueueItemVO item = Mockito.mock(SyncQueueItemVO.class);
+        Mockito.when(item.getContentId()).thenReturn(contentId);
+        Mockito.when(item.getId()).thenReturn(itemId);
+
+        AsyncJobVO job = Mockito.mock(AsyncJobVO.class);
+        Mockito.when(job.getId()).thenReturn(jobId);
+        Mockito.when(_jobDao.findById(contentId)).thenReturn(job);
+
+        // Simulate the DB deadlock the catch block was written to survive.
+        Mockito.doThrow(new CloudRuntimeException("simulated DB deadlock"))
+                .when(_jobDao).update(Mockito.anyLong(), Mockito.any(AsyncJobVO.class));
+
+        // Stub the executor path so we can assert whether it is reached (and avoid the real submit).
+        Mockito.doNothing().when(asyncJobManager).scheduleExecution(Mockito.any(AsyncJobVO.class));
+
+        asyncJobManager.executeQueueItem(item, false);
+
+        // The queue item was returned for a later retry; the job must NOT also be scheduled now, or it
+        // would run twice (once here and once when the heartbeat re-dequeues the returned item).
+        Mockito.verify(_queueMgr).returnItem(itemId);
+        Mockito.verify(asyncJobManager, Mockito.never()).scheduleExecution(Mockito.any(AsyncJobVO.class));
+    }
+}


### PR DESCRIPTION
### Description

In executeQueueItem, when persisting the executing management-server id fails
(the DB-deadlock case the catch block exists for), the queue item is returned to
the queue so it can be retried later. Execution then fell through to
scheduleExecution(job), so the job was dispatched now AND re-dequeued and
dispatched again by the heartbeat, running the same job (VM start/deploy, volume
create, snapshot, etc.) twice concurrently and defeating the sync queue's
serialization.

Return after returning the item so the job runs once, on the retry.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [x] Minor

### How Has This Been Tested?

Added a unit test that makes the executing-msid update throw and asserts the
queue item is returned and the job is not also scheduled. Also built the standard
packages and deployed on a KVM advanced zone.