### PR TITLE
server: report distinct read/write volume throttle rates

### DIFF
--- a/server/src/main/java/com/cloud/api/query/dao/VolumeJoinDaoImpl.java
+++ b/server/src/main/java/com/cloud/api/query/dao/VolumeJoinDaoImpl.java
@@ -77,6 +77,13 @@ public class VolumeJoinDaoImpl extends GenericDaoBaseWithTagInformation<VolumeJo
         _count = "select count(distinct id) from volume_view WHERE ";
     }
 
+    protected void setThrottleRates(VolumeResponse volResponse, VolumeJoinVO volume) {
+        volResponse.setBytesReadRate(volume.getBytesReadRate());
+        volResponse.setBytesWriteRate(volume.getBytesWriteRate());
+        volResponse.setIopsReadRate(volume.getIopsReadRate());
+        volResponse.setIopsWriteRate(volume.getIopsWriteRate());
+    }
+
     @Override
     public VolumeResponse newVolumeResponse(ResponseView view, VolumeJoinVO volume) {
         VolumeResponse volResponse = new VolumeResponse();
@@ -206,10 +213,7 @@ public class VolumeJoinDaoImpl extends GenericDaoBaseWithTagInformation<VolumeJo
             if (view == ResponseView.Full) {
                 volResponse.setStorageType(volume.isUseLocalStorage() ? ServiceOffering.StorageType.local.toString() : ServiceOffering.StorageType.shared.toString());
             }
-            volResponse.setBytesReadRate(volume.getBytesReadRate());
-            volResponse.setBytesWriteRate(volume.getBytesReadRate());
-            volResponse.setIopsReadRate(volume.getIopsWriteRate());
-            volResponse.setIopsWriteRate(volume.getIopsWriteRate());
+            setThrottleRates(volResponse, volume);
 
         }
 

--- a/server/src/test/java/com/cloud/api/query/dao/VolumeJoinDaoImplTest.java
+++ b/server/src/test/java/com/cloud/api/query/dao/VolumeJoinDaoImplTest.java
@@ -18,10 +18,12 @@ package com.cloud.api.query.dao;
 
 import com.cloud.api.query.vo.VolumeJoinVO;
 import org.apache.cloudstack.api.response.VolumeResponse;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -41,6 +43,23 @@ public class VolumeJoinDaoImplTest extends GenericDaoBaseWithTagInformationBaseT
     @Test
     public void testUpdateVolumeTagInfo(){
         testUpdateTagInformation(_volumeJoinDaoImpl, volume, volumeResponse);
+    }
+
+    @Test
+    public void testSetThrottleRatesMapsReadAndWriteDistinctly() {
+        VolumeJoinVO vol = Mockito.mock(VolumeJoinVO.class);
+        Mockito.when(vol.getBytesReadRate()).thenReturn(100L);
+        Mockito.when(vol.getBytesWriteRate()).thenReturn(200L);
+        Mockito.when(vol.getIopsReadRate()).thenReturn(300L);
+        Mockito.when(vol.getIopsWriteRate()).thenReturn(400L);
+
+        VolumeResponse response = new VolumeResponse();
+        _volumeJoinDaoImpl.setThrottleRates(response, vol);
+
+        Assert.assertEquals(Long.valueOf(100L), response.getBytesReadRate());
+        Assert.assertEquals(Long.valueOf(200L), response.getBytesWriteRate());
+        Assert.assertEquals(Long.valueOf(300L), response.getIopsReadRate());
+        Assert.assertEquals(Long.valueOf(400L), response.getIopsWriteRate());
     }
 
 }


### PR DESCRIPTION
VolumeJoinDaoImpl.newVolumeResponse fed the read getter to the write setter for the byte rate, and the write getter to the read setter for IOPS, so listVolumes returned the read byte-rate as the write byte-rate and the write IOPS as the read IOPS for any volume with asymmetric throttling. Map each rate to its own field.

Tested: new unit test on the extracted setThrottleRates helper; VolumeJoinDaoImplTest green