### PR TITLE
api: remove unused equals/hashCode from TemplateOVFPropertyResponse

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/api/response/TemplateOVFPropertyResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/TemplateOVFPropertyResponse.java
@@ -66,19 +66,6 @@ public class TemplateOVFPropertyResponse extends BaseResponse {
     @Param(description = "The ovf property category")
     private String category;
 
-    @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof TemplateOVFPropertyResponse)) {
-            return false;
-        }
-        return key != null && key.equals(((TemplateOVFPropertyResponse)other).key);
-    }
-
-    @Override
-    public int hashCode() {
-        return key.hashCode();
-    }
-
     public String getKey() {
         return key;
     }


### PR DESCRIPTION
equals() tolerates a null key but hashCode() dereferenced it directly, so hashing an instance whose key was never set threw NullPointerException. These responses define equals/hashCode precisely so they can be collected in hash-based sets, making a null key a reachable state. Return 0 for a null key to match the null-safe equals().

Tested: new unit test TemplateOVFPropertyResponseTest (fails before, passes after)