### PR TITLE
server: fix ClassCastException importing an ACL rule without a traffic type

### DIFF
--- a/server/src/main/java/com/cloud/network/vpc/NetworkACLServiceImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/NetworkACLServiceImpl.java
@@ -1109,7 +1109,7 @@ public class NetworkACLServiceImpl extends ManagerBase implements NetworkACLServ
             throw new InvalidParameterValueException("Protocol is required");
         }
         String action = (String) ruleMap.getOrDefault(ApiConstants.ACTION, "deny");
-        String trafficType = (String) ruleMap.getOrDefault(ApiConstants.TRAFFIC_TYPE, NetworkACLItem.TrafficType.Ingress);
+        String trafficType = (String) ruleMap.getOrDefault(ApiConstants.TRAFFIC_TYPE, NetworkACLItem.TrafficType.Ingress.toString());
         String forDisplay = (String) ruleMap.getOrDefault(ApiConstants.FOR_DISPLAY, "true");
 
         // Create ACL rule using the service

--- a/server/src/test/java/com/cloud/network/vpc/NetworkACLServiceImplTest.java
+++ b/server/src/test/java/com/cloud/network/vpc/NetworkACLServiceImplTest.java
@@ -38,7 +38,10 @@ import com.cloud.network.vpc.dao.VpcDao;
 import com.cloud.utils.net.NetUtils;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.command.user.network.CreateNetworkACLCmd;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.apache.cloudstack.api.command.user.network.MoveNetworkAclItemCmd;
 import org.apache.cloudstack.api.command.user.network.UpdateNetworkACLItemCmd;
 import org.apache.cloudstack.api.command.user.network.UpdateNetworkACLListCmd;
@@ -1505,5 +1508,18 @@ public class NetworkACLServiceImplTest {
         Mockito.doReturn(null).when(vpcDaoMock).findById(Mockito.anyLong());
 
         networkAclServiceImpl.validateAclAssociatedToVpc(networkMockVpcMockId, accountMock, SOME_UUID);
+    }
+
+    @Test
+    public void createACLRuleFromMapDefaultsTrafficTypeToIngress() {
+        Map<String, Object> ruleMap = new HashMap<>();
+        ruleMap.put(ApiConstants.PROTOCOL, "tcp");
+        Mockito.doReturn(Mockito.mock(NetworkACLItem.class)).when(networkAclServiceImpl).createNetworkACLItem(Mockito.any());
+
+        ReflectionTestUtils.invokeMethod(networkAclServiceImpl, "createACLRuleFromMap", ruleMap, 1L);
+
+        ArgumentCaptor<CreateNetworkACLCmd> captor = ArgumentCaptor.forClass(CreateNetworkACLCmd.class);
+        Mockito.verify(networkAclServiceImpl).createNetworkACLItem(captor.capture());
+        Assert.assertEquals(NetworkACLItem.TrafficType.Ingress, captor.getValue().getTrafficType());
     }
 }


### PR DESCRIPTION
createACLRuleFromMap passed the enum NetworkACLItem.TrafficType.Ingress as the getOrDefault default for a String variable, so importing a rule that omits the optional traffictype threw ClassCastException and every such rule was silently rejected. Use the enum's string form so the intended Ingress default applies.

Tested: new unit test createACLRuleFromMapDefaultsTrafficTypeToIngress (fails before, passes after); NetworkACLServiceImplTest green.