### PR TITLE
server: treat a zero-capacity storage pool as full

### DIFF
--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -3444,6 +3444,9 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         }
 
         long totalSize = pool.getCapacityBytes();
+        if (totalSize <= 0) {
+            return false;
+        }
         long usedSize = getUsedSize(pool);
         double usedPercentage = ((double)usedSize / (double)totalSize);
         double storageUsedThreshold = CapacityManager.StorageCapacityDisableThreshold.valueIn(pool.getId());

--- a/server/src/test/java/com/cloud/storage/StorageManagerImplTest.java
+++ b/server/src/test/java/com/cloud/storage/StorageManagerImplTest.java
@@ -1716,4 +1716,15 @@ public class StorageManagerImplTest {
 
         storageManagerImpl.discoverObjectStore(name, url, size, providerName, details);
     }
+
+    @Test
+    public void checkUsagedSpaceReturnsFalseForZeroCapacityPool() {
+        StoragePool pool = Mockito.mock(StoragePool.class);
+        Mockito.when(pool.isManaged()).thenReturn(false);
+        Mockito.when(pool.getCapacityBytes()).thenReturn(0L);
+
+        Boolean result = ReflectionTestUtils.invokeMethod(storageManagerImpl, "checkUsagedSpace", pool);
+
+        Assert.assertFalse(result);
+    }
 }


### PR DESCRIPTION
checkUsagedSpace divided used by total capacity without guarding a zero total. A pool reporting capacityBytes == 0 with zero used produced NaN, and NaN >= threshold is false, so the method returned true and reported that a pool with no capacity had space, letting allocation or resize proceed onto it. Return false when the pool reports no capacity.

Tested: new unit test checkUsagedSpaceReturnsFalseForZeroCapacityPool (fails before, passes after); StorageManagerImplTest green.