### PR TITLE
utils: do not require an IPv4 default route to find the default NIC

### DIFF
--- a/utils/src/main/java/com/cloud/utils/net/NetUtils.java
+++ b/utils/src/main/java/com/cloud/utils/net/NetUtils.java
@@ -267,6 +267,11 @@ public class NetUtils {
                 return null;
             }
 
+            if (nic == null) {
+                LOGGER.warn("Unable to find a network interface named [{}], cannot determine the default host IP.", pubNic);
+                return null;
+            }
+
             String[] info = null;
             try {
                 info = NetUtils.getNetworkParams(nic);
@@ -295,6 +300,11 @@ public class NetUtils {
             return addrs;
         }
 
+        if (nic == null) {
+            LOGGER.warn("Unable to find a network interface named [{}], no default NIC IPs will be returned.", pubNic);
+            return addrs;
+        }
+
         for (InterfaceAddress address : nic.getInterfaceAddresses()) {
             addrs.add(address.getAddress().getHostAddress().split("%")[0]);
         }
@@ -306,7 +316,25 @@ public class NetUtils {
             final String defDev = Script.runSimpleBashScript("/sbin/route -n get default 2> /dev/null | grep interface | awk '{print $2}'");
             return defDev;
         }
-        return Script.runSimpleBashScript("ip route show default 0.0.0.0/0 | head -1 | awk '{print $5}'");
+        final String defaultIp4Device = getDefaultEthDevice(false);
+        if (defaultIp4Device != null) {
+            return defaultIp4Device;
+        }
+        LOGGER.debug("No IPv4 default route found, falling back to the IPv6 default route to determine the default network device.");
+        return getDefaultEthDevice(true);
+    }
+
+    /**
+     * Returns the name of the network device used by the IPv4 or IPv6 default route, or null when there is no such
+     * default route.
+     *
+     * An IPv4 default route is not a requirement, a host can be IPv6-only or have IPv4 connectivity without a default
+     * route, therefore both address families are looked up separately.
+     */
+    protected static String getDefaultEthDevice(final boolean ipv6) {
+        final String command = String.format("ip -%d route show default | awk '{for (i = 1; i < NF; i++) if ($i == \"dev\") {print $(i + 1); exit}}'",
+                ipv6 ? 6 : 4);
+        return Script.runSimpleBashScript(command);
     }
 
     public static String getLocalIPString() {

--- a/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
+++ b/utils/src/test/java/com/cloud/utils/net/NetUtilsTest.java
@@ -43,12 +43,15 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import com.cloud.utils.Pair;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.NetUtils.SupersetOrSubset;
+import com.cloud.utils.script.Script;
 import com.googlecode.ipv6.IPv6Address;
 import com.googlecode.ipv6.IPv6Network;
 
@@ -745,6 +748,41 @@ public class NetUtilsTest {
         final String defaultHostIp = NetUtils.getDefaultHostIp();
         if (defaultHostIp != null) {
             assertTrue(NetUtils.getAllDefaultNicIps().stream().anyMatch(defaultHostIp::contains));
+        }
+    }
+
+    @Test
+    public void testAllIpsOfDefaultNicWhenDeviceDoesNotExist() {
+        try (MockedStatic<Script> scriptMocked = Mockito.mockStatic(Script.class)) {
+            scriptMocked.when(() -> Script.runSimpleBashScript(Mockito.anyString())).thenReturn("nonexistent0");
+            Assert.assertTrue(NetUtils.getAllDefaultNicIps().isEmpty());
+        }
+    }
+
+    @Test
+    public void testAllIpsOfDefaultNicWithoutDefaultRoute() {
+        try (MockedStatic<Script> scriptMocked = Mockito.mockStatic(Script.class)) {
+            scriptMocked.when(() -> Script.runSimpleBashScript(Mockito.anyString())).thenReturn(null);
+            Assert.assertTrue(NetUtils.getAllDefaultNicIps().isEmpty());
+        }
+    }
+
+    @Test
+    public void testGetDefaultEthDeviceFallsBackToIpv6() {
+        Assume.assumeFalse(SystemUtils.IS_OS_MAC);
+        try (MockedStatic<Script> scriptMocked = Mockito.mockStatic(Script.class)) {
+            scriptMocked.when(() -> Script.runSimpleBashScript(Mockito.contains("ip -4"))).thenReturn(null);
+            scriptMocked.when(() -> Script.runSimpleBashScript(Mockito.contains("ip -6"))).thenReturn("eth0");
+            Assert.assertEquals("eth0", NetUtils.getDefaultEthDevice());
+        }
+    }
+
+    @Test
+    public void testGetDefaultEthDevicePrefersIpv4() {
+        Assume.assumeFalse(SystemUtils.IS_OS_MAC);
+        try (MockedStatic<Script> scriptMocked = Mockito.mockStatic(Script.class)) {
+            scriptMocked.when(() -> Script.runSimpleBashScript(Mockito.contains("ip -4"))).thenReturn("eth0");
+            Assert.assertEquals("eth0", NetUtils.getDefaultEthDevice());
         }
     }
 


### PR DESCRIPTION
### Description

A CloudStack management server does not need an IPv4 default route. It can be IPv6-first, or — as in the setup that triggered this — have IPv4 connectivity to the POD network and the KVM agents without any IPv4 default gateway. Today such a management server does not boot:

```
ERROR [o.a.c.s.l.CloudStackExtendedLifeCycle] (main:[]) (logid:) Error on configuring bean RootCAProvider -
Cannot invoke "java.net.NetworkInterface.getInterfaceAddresses()" because "nic" is null
java.lang.NullPointerException: Cannot invoke "java.net.NetworkInterface.getInterfaceAddresses()" because "nic" is null
        at com.cloud.utils.net.NetUtils.getAllDefaultNicIps(NetUtils.java:298)
        at org.apache.cloudstack.ca.provider.RootCAProvider.loadManagementKeyStore(RootCAProvider.java:409)
        at org.apache.cloudstack.ca.provider.RootCAProvider.setupCA(RootCAProvider.java:521)
        at org.apache.cloudstack.ca.provider.RootCAProvider.configure(RootCAProvider.java:548)
        ...
ERROR [o.a.c.s.m.m.i.DefaultModuleDefinitionSet] (main:[]) (logid:) Failed to load module [root-ca]
```

`RootCAProvider` calls `NetUtils.getAllDefaultNicIps()` to collect the IPs that go into the management server certificate's SANs. That in turn calls `NetUtils.getDefaultEthDevice()`, which ran:

```
ip route show default 0.0.0.0/0 | head -1 | awk '{print $5}'
```

Two problems with that:

1. **It only looks at IPv4, and it does not always return a device name.** `Script` merges stderr into stdout (`ProcessBuilder.redirectErrorStream(true)`), so anything the shell or `ip` writes on stderr becomes the "device name". That non-null, non-device string is handed to `NetworkInterface.getByName()`, which returns `null`, and the unchecked dereference on the next line throws the NPE above — which aborts the whole `root-ca` module and therefore the management server boot.

2. **Column 5 is not the device.** `$5` only happens to be the device for routes shaped like `default via <gw> dev <name> ...`. For an on-link default route it is wrong:

   | route | old `$5` | new |
   |---|---|---|
   | `default via 10.0.0.1 dev eth0 proto static metric 100` | `eth0` | `eth0` |
   | `default dev eth0 scope link` | `link` ❌ | `eth0` |
   | `default via fe80::1 dev eno1 proto ra metric 1024 expires 1798sec pref medium` | `eno1` | `eno1` |
   | `default dev eno1 proto kernel metric 256 pref medium` | `kernel` ❌ | `eno1` |
   | multipath (`default proto static` + `nexthop ... dev eth0 ...`) | *(empty)* | `eth0` |

### Fix

Small change, all in `NetUtils`:

* The device name is taken from the token that follows `dev`, rather than from a fixed column. Correct for every route layout above, including multipath.
* `ip -4 route show default` is queried first; if there is no IPv4 default route, `ip -6 route show default` is used. An IPv6-first management server now resolves its default NIC and gets its addresses (both families) into the management server certificate, instead of getting nothing.
* The results of `NetworkInterface.getByName()` are null-checked in both `getAllDefaultNicIps()` and `getDefaultHostIp()`, so an unresolvable device name degrades to "no default NIC found" with a warning in the log instead of killing the boot.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Four unit tests added to `NetUtilsTest`, covering the IPv4→IPv6 fallback, the IPv4-preferred path, an unresolvable device name, and no default route at all.

The `awk` expression was checked against the route outputs in the table above.

> [!NOTE]
> `NetUtilsTest#testAllIpsOfDefaultNic` fails on JDK 26 with `UnsupportedOperationException` from `Collections.reverse()` in `getNetworkParams()`, because `NetworkInterface.getInterfaceAddresses()` now returns an immutable list. That is pre-existing on `main` and unrelated to this PR.
