### PR TITLE
UI: fix clone offering forms silently reverting user edits on services

### DIFF
--- a/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/vpc/VpcManagerImpl.java
@@ -1079,6 +1079,11 @@ public class VpcManagerImpl extends ManagerBase implements VpcManager, VpcProvis
                 ConfigurationManagerImpl.setField(cmd, "specifyAsNumber", sourceOffering.isSpecifyAsNumber());
             }
 
+            Boolean conserveModeFieldValue = getRawFieldValue(cmd, "conserveMode", Boolean.class);
+            if (conserveModeFieldValue == null) {
+                ConfigurationManagerImpl.setField(cmd, "conserveMode", sourceOffering.isConserveMode());
+            }
+
             if (cmd.getInternetProtocol() == null) {
                 String internetProtocol = vpcOfferingDetailsDao.getDetail(sourceOffering.getId(), ApiConstants.INTERNET_PROTOCOL);
                 if (internetProtocol != null) {

--- a/ui/src/views/offering/CloneNetworkOffering.vue
+++ b/ui/src/views/offering/CloneNetworkOffering.vue
@@ -1228,12 +1228,7 @@ export default {
     },
     handleSupportedServiceChange (service, checked, provider) {
       if (checked) {
-        const correctProvider = this.serviceProviderMap[service]
-        if (correctProvider && provider !== correctProvider) {
-          this.selectedServiceProviderMap[service] = correctProvider
-        } else {
-          this.selectedServiceProviderMap[service] = provider
-        }
+        this.selectedServiceProviderMap[service] = provider
       } else {
         delete this.selectedServiceProviderMap[service]
       }
@@ -1292,6 +1287,10 @@ export default {
 
         if (values.guestiptype) {
           params.guestiptype = values.guestiptype
+        }
+
+        if (values.forvpc === true) {
+          params.forvpc = true
         }
 
         // Use composable for service capability params

--- a/ui/src/views/offering/CloneVpcOffering.vue
+++ b/ui/src/views/offering/CloneVpcOffering.vue
@@ -405,7 +405,7 @@ export default {
       this.fetchZoneData()
       this.fetchIpv6NetworkOfferingConfiguration()
       this.fetchRoutedNetworkConfiguration()
-      this.fetchSupportedServiceData()
+      this.fetchSupportedServiceData(true)
     },
     isAdmin () {
       return isAdmin()
@@ -455,7 +455,7 @@ export default {
         this.zoneLoading = false
       })
     },
-    fetchSupportedServiceData () {
+    fetchSupportedServiceData (isInitialLoad = false) {
       this.supportedServiceLoading = true
       getAPI('listSupportedNetworkServices', {}).then(json => {
         const networkServices = json.listsupportednetworkservicesresponse.networkservice || []
@@ -491,7 +491,11 @@ export default {
         this.supportedServiceLoading = false
 
         this.$nextTick(() => {
-          this.populateFormFromResource()
+          if (isInitialLoad) {
+            this.populateFormFromResource()
+          } else {
+            this.syncServiceSelectionsForCurrentMode()
+          }
         })
       })
     },
@@ -656,6 +660,45 @@ export default {
         this.form.nsxsupportlb = Boolean(this.serviceProviderMap.Lb)
       }
     },
+    syncServiceSelectionsForCurrentMode () {
+      const updatedServices = this.supportedServices.map(svc => {
+        const serviceCopy = { ...svc, provider: [...svc.provider] }
+        const providerName = this.selectedServiceProviderMap[serviceCopy.name]
+
+        if (providerName) {
+          const providerIndex = serviceCopy.provider.findIndex(p => p.name === providerName)
+          if (providerIndex > 0) {
+            const targetProvider = serviceCopy.provider[providerIndex]
+            serviceCopy.provider.splice(providerIndex, 1)
+            serviceCopy.provider.unshift(targetProvider)
+          }
+          serviceCopy.defaultChecked = true
+          serviceCopy.selectedProvider = providerName
+        } else {
+          serviceCopy.defaultChecked = false
+          serviceCopy.selectedProvider = null
+        }
+        return serviceCopy
+      })
+      this.supportedServices = updatedServices
+
+      const availableNames = new Set(updatedServices.map(svc => svc.name))
+      Object.keys(this.selectedServiceProviderMap).forEach(name => {
+        if (!availableNames.has(name)) {
+          delete this.selectedServiceProviderMap[name]
+        }
+      })
+
+      this.connectivityServiceChecked = Boolean(this.selectedServiceProviderMap.Connectivity)
+      this.sourceNatServiceChecked = Boolean(this.selectedServiceProviderMap.SourceNat)
+
+      this.$nextTick(() => {
+        this.servicesReady = true
+        this.$nextTick(() => {
+          this.checkVpcVirtualRouterForServices()
+        })
+      })
+    },
     async handleProviderChange (value) {
       this.provider = value
       if (this.provider === 'NSX') {
@@ -682,12 +725,7 @@ export default {
     },
     handleSupportedServiceChange (service, checked, provider) {
       if (checked) {
-        const correctProvider = this.serviceProviderMap[service]
-        if (correctProvider && provider !== correctProvider) {
-          this.selectedServiceProviderMap[service] = correctProvider
-        } else {
-          this.selectedServiceProviderMap[service] = provider
-        }
+        this.selectedServiceProviderMap[service] = provider
       } else {
         delete this.selectedServiceProviderMap[service]
       }

--- a/ui/src/views/offering/CloneVpcOffering.vue
+++ b/ui/src/views/offering/CloneVpcOffering.vue
@@ -212,6 +212,12 @@
             </a-select-option>
           </a-select>
         </a-form-item>
+        <a-form-item name="conservemode" ref="conservemode">
+          <template #label>
+            <tooltip-label :title="$t('label.conservemode')" :tooltip="apiParams.conservemode.description"/>
+          </template>
+          <a-switch v-model:checked="form.conservemode" />
+        </a-form-item>
         <a-form-item name="ispublic" ref="ispublic" :label="$t('label.ispublic')" v-if="isAdmin()">
           <a-switch v-model:checked="form.ispublic" @change="val => { isPublic = val }" />
         </a-form-item>
@@ -308,7 +314,6 @@ export default {
     return {
       selectedDomains: [],
       selectedZones: [],
-      isConserveMode: true,
       internetProtocolValue: 'ipv4',
       domains: [],
       domainLoading: false,
@@ -854,6 +859,10 @@ export default {
 
         if (values.enable !== undefined) {
           params.enable = values.enable
+        }
+
+        if (values.conservemode !== undefined) {
+          params.conservemode = values.conservemode
         }
 
         this.loading = true


### PR DESCRIPTION
### Description

This PR fixes: https://github.com/apache/cloudstack/issues/14056
<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [X] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Network Offering clone:

1. Clone an existing isolated network offering, change say, userdata provider from VirtualRouter to ConfigDrive and submit. listNetworkOfferings on the result and confirm the new provider actually persisted.
2. Clone the same offering, leave services untouched, submit - confirm it clones same as source
2. Clone an NSX-backed offering - confirm services/providers stay greyed out and fixed, unaffected by any of the above.

VPC Offering clone:

1. Clone a VPC offering, edit Name/Display Text/Service Offering/Redundant Router, then change Network Mode (NATTED <->ROUTED) before submitting - confirm those edits survive 
2. While in NATTED, check/uncheck a couple of services and change their providers, then flip to ROUTED and back to NATTED - confirm the edits to available services are preserved, and confirm mode-excluded services (SourceNat/StaticNat/Lb/PortForwarding/Vpn) are unchecked in ROUTED and require an explicit re-check after returning to NATTED
3. Submit after a mode change (as in test 2) and confirm the API payload doesn't include stale entries for services no longer shown in the form .


<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
