### PR TITLE
ui: filter unreachable pools on live migration with storage wizard

### DIFF
--- a/ui/src/components/view/InstanceVolumesStoragePoolSelectListView.vue
+++ b/ui/src/components/view/InstanceVolumesStoragePoolSelectListView.vue
@@ -54,6 +54,7 @@
       <volume-storage-pool-select-form
         :resource="selectedVolumeForStoragePoolSelection"
         :clusterId="storagePoolsClusterId"
+        :hostId="hostId"
         :autoAssignAllowed="storagePoolsClusterId != null"
         :isOpen="!(!selectedVolumeForStoragePoolSelection.id)"
         @close-action="closeVolumeStoragePoolSelector()"
@@ -77,6 +78,11 @@ export default {
       required: true
     },
     clusterId: {
+      type: String,
+      required: false,
+      default: null
+    },
+    hostId: {
       type: String,
       required: false,
       default: null

--- a/ui/src/components/view/StoragePoolSelectView.vue
+++ b/ui/src/components/view/StoragePoolSelectView.vue
@@ -110,6 +110,11 @@ export default {
       required: false,
       default: null
     },
+    hostId: {
+      type: String,
+      required: false,
+      default: null
+    },
     suitabilityEnabled: {
       type: Boolean,
       required: false,
@@ -178,6 +183,12 @@ export default {
       if (newValue !== oldValue) {
         this.page = 1
       }
+    },
+    hostId () {
+      if (!this.resource || !this.resource.id) {
+        return
+      }
+      this.reset()
     }
   },
   methods: {
@@ -204,7 +215,9 @@ export default {
           page: this.page,
           pagesize: this.pageSize
         }
-        if (this.clusterId) {
+        if (this.hostId) {
+          params.hostid = this.hostId
+        } else if (this.clusterId) {
           params.clusterid = this.clusterId
         }
         getAPI('listStoragePools', params).then(response => {

--- a/ui/src/components/view/VolumeStoragePoolSelectForm.vue
+++ b/ui/src/components/view/VolumeStoragePoolSelectForm.vue
@@ -21,6 +21,7 @@
       ref="selectionView"
       :resource="resource"
       :clusterId="clusterId"
+      :hostId="hostId"
       :suitabilityEnabled="suitabilityEnabled"
       :autoAssignAllowed="autoAssignAllowed"
       @select="handleSelect" />
@@ -60,6 +61,11 @@ export default {
       required: true
     },
     clusterId: {
+      type: String,
+      required: false,
+      default: null
+    },
+    hostId: {
       type: String,
       required: false,
       default: null

--- a/ui/src/views/compute/MigrateWizard.vue
+++ b/ui/src/views/compute/MigrateWizard.vue
@@ -124,6 +124,7 @@
         ref="storagePoolSelection"
         :autoAssignAllowed="false"
         :resource="resource"
+        :hostId="selectedHost.id && selectedHost.id !== -1 ? selectedHost.id : null"
         @select="handleStoragePoolChange" />
     </div>
     <instance-volumes-storage-pool-select-list-view
@@ -132,6 +133,7 @@
       class="top-spaced"
       :resource="resource"
       :clusterId="selectedHost.id ? selectedHost.clusterid : null"
+      :hostId="selectedHost.id && selectedHost.id !== -1 ? selectedHost.id : null"
       @select="handleVolumeToPoolChange" />
 
     <a-divider />
@@ -284,7 +286,7 @@ export default {
       this.selectedHost = host
       this.selectedVolumeForStoragePoolSelection = {}
       this.volumeToPoolSelection = []
-      if (this.migrateWithStorage) {
+      if (this.migrateWithStorage && this.migrateMode !== 1) {
         this.$refs.volumeToPoolSelect.resetSelection()
       }
     },


### PR DESCRIPTION
### Description

The "Migrate instance to another host" wizard lets an operator pick a destination host and, optionally, a destination
primary storage. Today the storage list is not filtered by the selected host, so it offers primary storages the host cannot reach. This filters that list down to the storages actually accessible to the selected host.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [X] Minor

### How Has This Been Tested?

Tested manually in a local environment by migrating an Instance between 2 hosts with distinct accessible primary storages.