### PR TITLE
linstor: escape dashes in the LVM volume group name of snapshot paths

### DIFF
--- a/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
+++ b/plugins/storage/volume/linstor/src/main/java/org/apache/cloudstack/storage/datastore/util/LinstorUtil.java
@@ -204,8 +204,10 @@ public class LinstorUtil {
         final String path;
         switch (sp.getProviderKind()) {
             case LVM_THIN:
+                // device-mapper doubles every dash in the VG and LV name, so the VG part needs escaping too
+                final String vgName = backingPool.split("/")[0];
                 path = String.format("/dev/mapper/%s-%s_%s_%s",
-                    backingPool.split("/")[0], rscName.replace("-", "--"), suffix, snapshotName.replace("-", "--"));
+                    vgName.replace("-", "--"), rscName.replace("-", "--"), suffix, snapshotName.replace("-", "--"));
                 break;
             case ZFS:
             case ZFS_THIN:

--- a/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
+++ b/plugins/storage/volume/linstor/src/test/java/org/apache/cloudstack/storage/datastore/util/LinstorUtilTest.java
@@ -104,6 +104,20 @@ public class LinstorUtilTest {
         }
 
         {
+            // dashes in the volume group name must be escaped as well (GH issue #14011)
+            StoragePool spLVMThin = new StoragePool();
+            Properties lvmThinProps = new Properties();
+            lvmThinProps.put("StorDriver/StorPoolName", "linstor_pool-lvm-thin/thin");
+            spLVMThin.setProps(lvmThinProps);
+            spLVMThin.setProviderKind(ProviderKind.LVM_THIN);
+            String snapPath = LinstorUtil.getSnapshotPath(spLVMThin,
+                "cs-12fc4055-3985-4025-8eb5-d6fd53effe37", "cs-d7aea646-5f40-46a2-b9dc-77e41ea29336");
+            Assert.assertEquals(
+                "/dev/mapper/linstor_pool--lvm--thin-cs--12fc4055--3985--4025--8eb5--d6fd53effe37_00000_cs--d7aea646--5f40--46a2--b9dc--77e41ea29336",
+                snapPath);
+        }
+
+        {
             StoragePool spZFS = new StoragePool();
             Properties zfsProps = new Properties();
             zfsProps.put("StorDriver/StorPoolName", "linstorPool");


### PR DESCRIPTION
### Description

Device-mapper doubles every dash in both the volume group and the logical volume name. getSnapshotPath only escaped the resource and snapshot name, so on a VG like "linstor_pool-lvm-thin" the computed /dev/mapper path did not exist and backing up a snapshot to secondary storage failed with "qemu-img: Could not open".

Fixes #14011

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Added unittests for this corner case
