### PR TITLE
volume: enforce storage pool disable threshold when creating a volume on an explicit pool

### DIFF
--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1127,6 +1127,14 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             throw new InvalidParameterValueException(String.format("Disk offering: %s is not compatible with the storage pool", diskOffering.getUuid()));
         }
 
+        HypervisorType hypervisorType = _volsDao.getHypervisorType(volume.getId());
+        DiskProfile diskProfile = new DiskProfile(volume, diskOffering, hypervisorType);
+        Pair<Volume, DiskProfile> volumeDiskProfilePair = new Pair<>(volume, diskProfile);
+        if (!storageMgr.storagePoolHasEnoughSpace(Collections.singletonList(volumeDiskProfilePair), storagePool)) {
+            throw new InvalidParameterValueException(String.format("Cannot create volume %s on storage pool %s as the pool does not have enough space " +
+                    "or has crossed the disable threshold.", volume.getUuid(), storagePool.getName()));
+        }
+
         DataStore dataStore = dataStoreMgr.getDataStore(storageId, DataStoreRole.Primary);
         VolumeInfo volumeInfo = volFactory.getVolume(volumeId, dataStore);
         AsyncCallFuture<VolumeApiResult> createVolumeFuture = volService.createVolumeAsync(volumeInfo, dataStore);

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -1135,7 +1135,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                     "or has crossed the disable threshold.", volume.getUuid(), storagePool.getName()));
         }
 
-        DataStore dataStore = dataStoreMgr.getDataStore(storageId, DataStoreRole.Primary);
+        DataStore dataStore = (DataStore) storagePool;
         VolumeInfo volumeInfo = volFactory.getVolume(volumeId, dataStore);
         AsyncCallFuture<VolumeApiResult> createVolumeFuture = volService.createVolumeAsync(volumeInfo, dataStore);
         VolumeApiResult createVolumeResult = createVolumeFuture.get();

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -2895,5 +2896,99 @@ public class VolumeApiServiceImplTest {
                     "Exception message must reference Stopped-state requirement, was: " + e.getMessage(),
                     e.getMessage() != null && e.getMessage().contains("VM should be in"));
         }
+    }
+
+    /**
+     * createVolumeOnStoragePool must reject the request when the target pool has crossed its
+     * storage capacity disable threshold, instead of silently creating the volume there.
+     */
+    @Test
+    public void testCreateVolumeOnStoragePool_DisableThresholdCrossed_ShouldThrow()
+            throws ExecutionException, InterruptedException {
+        long volumeId = 400L;
+        long storageId = 401L;
+        long diskOfferingId = 402L;
+        long dataCenterId = 1L;
+
+        VolumeVO volume = Mockito.mock(VolumeVO.class);
+        when(volume.getId()).thenReturn(volumeId);
+        when(volume.getDataCenterId()).thenReturn(dataCenterId);
+        when(volume.getDiskOfferingId()).thenReturn(diskOfferingId);
+        when(volume.getUuid()).thenReturn("volume-uuid");
+        when(volumeDaoMock.findById(volumeId)).thenReturn(volume);
+        when(volumeDaoMock.getHypervisorType(volumeId)).thenReturn(HypervisorType.KVM);
+
+        PrimaryDataStore storagePool = Mockito.mock(PrimaryDataStore.class);
+        when(storagePool.getStatus()).thenReturn(StoragePoolStatus.Up);
+        when(storagePool.getDataCenterId()).thenReturn(dataCenterId);
+        when(storagePool.getName()).thenReturn("pool-crossing-threshold");
+        when(dataStoreMgr.getDataStore(storageId, DataStoreRole.Primary)).thenReturn(storagePool);
+
+        DiskOfferingVO diskOffering = Mockito.mock(DiskOfferingVO.class);
+        when(_diskOfferingDao.findById(diskOfferingId)).thenReturn(diskOffering);
+
+        Mockito.doReturn(true).when(volumeApiServiceImpl).doesStoragePoolSupportDiskOffering(storagePool, diskOffering);
+
+        // Simulate the pool having crossed its storage.capacity/allocated disable threshold.
+        when(storageMgr.storagePoolHasEnoughSpace(anyList(), eq(storagePool))).thenReturn(false);
+
+        try {
+            invokePrivateMethod("createVolumeOnStoragePool", new Class[]{Long.class, Long.class}, volumeId, storageId);
+            Assert.fail("Expected an InvalidParameterValueException because the pool has crossed its disable threshold");
+        } catch (RuntimeException e) {
+            // invokePrivateMethod wraps the reflectively-thrown exception as:
+            // RuntimeException -> InvocationTargetException -> actual exception
+            Throwable cause = e.getCause();
+            if (cause instanceof InvocationTargetException) {
+                cause = cause.getCause();
+            }
+            Assert.assertTrue("Expected InvalidParameterValueException, was: " + cause,
+                    cause instanceof InvalidParameterValueException);
+            Assert.assertTrue("Exception message must reference the disable threshold, was: " + cause.getMessage(),
+                    cause.getMessage() != null && cause.getMessage().contains("disable threshold"));
+        }
+
+        Mockito.verify(volumeServiceMock, Mockito.never()).createVolumeAsync(any(), any());
+    }
+
+    /**
+     * createVolumeOnStoragePool must proceed with volume creation when the target pool has
+     * enough space and has not crossed its disable threshold.
+     */
+    @Test
+    public void testCreateVolumeOnStoragePool_EnoughSpace_ShouldCreateVolume()
+            throws ExecutionException, InterruptedException {
+        long volumeId = 410L;
+        long storageId = 411L;
+        long diskOfferingId = 412L;
+        long dataCenterId = 1L;
+
+        VolumeVO volume = Mockito.mock(VolumeVO.class);
+        when(volume.getId()).thenReturn(volumeId);
+        when(volume.getDataCenterId()).thenReturn(dataCenterId);
+        when(volume.getDiskOfferingId()).thenReturn(diskOfferingId);
+        when(volumeDaoMock.findById(volumeId)).thenReturn(volume);
+        when(volumeDaoMock.getHypervisorType(volumeId)).thenReturn(HypervisorType.KVM);
+
+        PrimaryDataStore storagePool = Mockito.mock(PrimaryDataStore.class);
+        when(storagePool.getStatus()).thenReturn(StoragePoolStatus.Up);
+        when(storagePool.getDataCenterId()).thenReturn(dataCenterId);
+        when(dataStoreMgr.getDataStore(storageId, DataStoreRole.Primary)).thenReturn(storagePool);
+
+        DiskOfferingVO diskOffering = Mockito.mock(DiskOfferingVO.class);
+        when(_diskOfferingDao.findById(diskOfferingId)).thenReturn(diskOffering);
+
+        Mockito.doReturn(true).when(volumeApiServiceImpl).doesStoragePoolSupportDiskOffering(storagePool, diskOffering);
+        when(storageMgr.storagePoolHasEnoughSpace(anyList(), eq(storagePool))).thenReturn(true);
+
+        when(volumeDataFactoryMock.getVolume(volumeId, storagePool)).thenReturn(volumeInfoMock);
+        when(volumeInfoMock.getId()).thenReturn(volumeId);
+        when(volumeServiceMock.createVolumeAsync(volumeInfoMock, storagePool)).thenReturn(asyncCallFutureVolumeapiResultMock);
+
+        VolumeVO result = invokePrivateMethod("createVolumeOnStoragePool",
+                new Class[]{Long.class, Long.class}, volumeId, storageId);
+
+        Assert.assertEquals(volume, result);
+        Mockito.verify(volumeServiceMock).createVolumeAsync(volumeInfoMock, storagePool);
     }
 }


### PR DESCRIPTION
### Description

`createVolume` accepts an admin-only `storageid` parameter to create the volume directly on a specified storage pool. Unlike the normal allocation path (which goes through `StoragePoolAllocator` → `StorageManager.storagePoolHasEnoughSpace` → `checkUsagedSpace`), this path fetched the pool directly by ID and only validated pool status, zone match, and disk-offering compatibility — it never checked the pool's storage capacity disable threshold (`storage.capacity.disablethreshold`) or allocated-capacity disable threshold before creating the volume there.

This means an admin passing `storageid` could push a storage pool past its configured disable threshold, defeating the safety mechanism the threshold exists for.

This is not considered a security issue since the `storageid` parameter is restricted to `RoleType.Admin` (added in 4.22.1), but it is a correctness bug.

### Fix

`VolumeApiServiceImpl#createVolumeOnStoragePool` now calls `StorageManager#storagePoolHasEnoughSpace` (the same check used by `migrateVolume`) before handing the volume off to `VolumeService#createVolumeAsync`, and rejects the request with an `InvalidParameterValueException` if the pool has crossed its disable threshold or doesn't have enough space.

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

### Feature/Enhancement Scale or Bug Severity

Bug Severity: Minor

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Added unit tests to `VolumeApiServiceImplTest`:
- `testCreateVolumeOnStoragePool_DisableThresholdCrossed_ShouldThrow` — verifies an `InvalidParameterValueException` is thrown and `createVolumeAsync` is never invoked when the pool has crossed its disable threshold.
- `testCreateVolumeOnStoragePool_EnoughSpace_ShouldCreateVolume` — verifies the volume is created normally when the pool has enough space.

Ran the full `VolumeApiServiceImplTest` suite (161 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)