### PR TITLE
cloud-guest-tool: add set-password command via the Qemu Guest Agent

### DIFF
--- a/agent/bindir/cloud-guest-tool.in
+++ b/agent/bindir/cloud-guest-tool.in
@@ -18,7 +18,8 @@
 
 #
 # Talk to a KVM guest through Libvirt and the Qemu Guest Agent
-# to retrieve information from the guest
+# to retrieve information from the guest or manage it, such as
+# setting a user's password
 #
 # System VMs have the Qemu Guest Agent installed by default
 # and should properly respond to such commands
@@ -28,12 +29,14 @@
 #
 
 import argparse
+import base64
+import getpass
 import json
 import sys
 import libvirt
 import libvirt_qemu
 
-COMMANDS = ["info", "ping", "fstrim"]
+COMMANDS = ["info", "ping", "fstrim", "set-password"]
 
 
 class Libvirt:
@@ -46,8 +49,11 @@ class Libvirt:
     def get_domain(self, name):
         return self.conn.lookupByName(name)
 
-    def agent_command(self, dom, cmd, flags=0, raw=False):
-        ret = libvirt_qemu.qemuAgentCommand(dom, json.dumps({'execute': cmd}),
+    def agent_command(self, dom, cmd, arguments=None, flags=0, raw=False):
+        request = {'execute': cmd}
+        if arguments is not None:
+            request['arguments'] = arguments
+        ret = libvirt_qemu.qemuAgentCommand(dom, json.dumps(request),
                                             self.timeout, flags)
         if raw:
             return ret
@@ -94,6 +100,25 @@ class GuestCommand:
 
         return {'result': result}, code
 
+    def set_password(self, username, password, crypted=False):
+        # guest-set-user-password expects the password base64-encoded and
+        # returns an empty dict on success
+        arguments = {
+            'username': username,
+            'password': base64.b64encode(password.encode('utf-8')).decode('ascii'),
+            'crypted': crypted,
+        }
+        result = self.virt.agent_command(self.dom, 'guest-set-user-password',
+                                         arguments=arguments)
+
+        res = False
+        code = 1
+        if len(result) == 0:
+            res = True
+            code = 0
+
+        return {'result': res}, code
+
 
 def main(args):
     command = args.command
@@ -109,6 +134,18 @@ def main(args):
             result, code = guestcmd.ping()
         elif command == 'fstrim':
             result, code = guestcmd.fstrim()
+        elif command == 'set-password':
+            password = args.password
+            if password is None:
+                if sys.stdin.isatty():
+                    password = getpass.getpass('New password for %s: ' % args.username)
+                else:
+                    password = sys.stdin.readline().rstrip('\n')
+            if not password:
+                print(json.dumps({'error': 'No password given via --password or stdin'}))
+                sys.exit(2)
+            result, code = guestcmd.set_password(args.username, password,
+                                                 args.crypted)
 
         print(json.dumps(result))
         sys.exit(code)
@@ -125,5 +162,12 @@ if __name__ == '__main__':
                         choices=COMMANDS)
     parser.add_argument('--timeout', type=int, required=False,
                         help='timeout in seconds', default=5)
+    parser.add_argument('--username', type=str, required=False, default='root',
+                        help='user whose password to set with the set-password command')
+    parser.add_argument('--password', type=str, required=False,
+                        help='new password for the set-password command; omit to read it '
+                             'from stdin, which keeps it out of the process list')
+    parser.add_argument('--crypted', action='store_true',
+                        help='the given password is already hashed in crypt(3) format')
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
### Description

This PR adds a `set-password` command to `cloud-guest-tool` (the KVM host-side helper that talks to Instances through the Qemu Guest Agent via libvirt).

It resets the password of a user inside a running Instance using QGA's `guest-set-user-password` command — no password server reachable from the guest and no reset script inside the template required, only a running qemu-guest-agent.

Usage:

```
# read the new password from stdin (preferred: keeps it out of the process list;
# an interactive terminal gets a no-echo prompt instead)
echo 'S3cret!' | cloud-guest-tool i-2-42-VM --command set-password

# other user, password as argument
cloud-guest-tool i-2-42-VM --command set-password --username admin --password 'S3cret!'

# pre-hashed crypt(3) value, applied verbatim by QGA
cloud-guest-tool i-2-42-VM --command set-password --crypted --password '$6$...'
```

The password is base64-encoded as the QGA protocol requires. `agent_command()` gained an optional `arguments` parameter for this — the first QGA command the tool sends with a payload; the existing `info`, `ping` and `fstrim` commands are unchanged.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

### How Has This Been Tested?

<pre>
root@hv-138-d03-21:~# cloudstack-guest-tool --username root --password cloudstack --command set-password i-2-30-VM
{"result": true}
root@hv-138-d03-21:~#
</pre>

I was now able to login with root/cloudstack into this VM via the console.