### PR TITLE
Add a soft host-tag VM placement preference (affinity processor)

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -574,6 +574,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.cloudstack</groupId>
+            <artifactId>cloud-plugin-host-tag-affinity</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cloudstack</groupId>
             <artifactId>cloud-plugin-api-solidfire-intg-test</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/plugins/affinity-group-processors/host-tag-affinity/pom.xml
+++ b/plugins/affinity-group-processors/host-tag-affinity/pom.xml
@@ -1,0 +1,30 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>cloud-plugin-host-tag-affinity</artifactId>
+    <name>Apache CloudStack Plugin - Host Tag Affinity Processor</name>
+    <parent>
+        <groupId>org.apache.cloudstack</groupId>
+        <artifactId>cloudstack-plugins</artifactId>
+        <version>24.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+</project>

--- a/plugins/affinity-group-processors/host-tag-affinity/src/main/java/org/apache/cloudstack/affinity/HostTagAffinityProcessor.java
+++ b/plugins/affinity-group-processors/host-tag-affinity/src/main/java/org/apache/cloudstack/affinity/HostTagAffinityProcessor.java
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.affinity;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
+import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import com.cloud.deploy.DeploymentPlan;
+import com.cloud.deploy.DeploymentPlanner.ExcludeList;
+import com.cloud.exception.AffinityConflictException;
+import com.cloud.host.Host;
+import com.cloud.host.HostVO;
+import com.cloud.host.dao.HostDao;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.VirtualMachineProfile;
+
+/**
+ * Soft VM-to-host placement preference: the affinity group name is treated as a host tag, and hosts
+ * carrying that tag in the VM's zone have their deployment priority raised. A preference, not a
+ * constraint — no host is excluded. Note: the priority channel is not honored by automatic DRS.
+ */
+public class HostTagAffinityProcessor extends AffinityProcessorBase implements AffinityGroupProcessor {
+
+    @Inject
+    protected AffinityGroupDao affinityGroupDao;
+    @Inject
+    protected AffinityGroupVMMapDao affinityGroupVMMapDao;
+    @Inject
+    protected HostDao hostDao;
+
+    @Override
+    public void process(VirtualMachineProfile vmProfile, DeploymentPlan plan, ExcludeList avoid, List<VirtualMachine> vmList) throws AffinityConflictException {
+        VirtualMachine vm = vmProfile.getVirtualMachine();
+        List<AffinityGroupVMMapVO> vmGroupMappings = affinityGroupVMMapDao.findByVmIdType(vm.getId(), getType());
+
+        for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
+            if (vmGroupMapping != null) {
+                processAffinityGroup(vmGroupMapping, plan, vm);
+            }
+        }
+    }
+
+    protected void processAffinityGroup(AffinityGroupVMMapVO vmGroupMapping, DeploymentPlan plan, VirtualMachine vm) {
+        AffinityGroupVO group = affinityGroupDao.findById(vmGroupMapping.getAffinityGroupId());
+        if (group == null || StringUtils.isBlank(group.getName())) {
+            return;
+        }
+
+        String hostTag = group.getName();
+        List<HostVO> preferredHosts = hostDao.listByHostTag(Host.Type.Routing, null, null, vm.getDataCenterId(), hostTag);
+        if (CollectionUtils.isEmpty(preferredHosts)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(String.format("No hosts carry tag [%s] in zone %s for VM %s; host-tag affinity is a no-op.",
+                        hostTag, vm.getDataCenterId(), vm));
+            }
+            return;
+        }
+
+        for (HostVO host : preferredHosts) {
+            Integer priority = adjustHostPriority(plan, host.getId());
+            if (logger.isDebugEnabled()) {
+                logger.debug(String.format("Raised host %s priority to %s (VM %s prefers hosts tagged [%s]).",
+                        host.getId(), priority, vm, hostTag));
+            }
+        }
+    }
+
+    protected Integer adjustHostPriority(DeploymentPlan plan, Long hostId) {
+        plan.adjustHostPriority(hostId, DeploymentPlan.HostPriorityAdjustment.HIGHER);
+        return plan.getHostPriorities().get(hostId);
+    }
+}

--- a/plugins/affinity-group-processors/host-tag-affinity/src/main/resources/META-INF/cloudstack/host-tag-affinity/module.properties
+++ b/plugins/affinity-group-processors/host-tag-affinity/src/main/resources/META-INF/cloudstack/host-tag-affinity/module.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+name=host-tag-affinity
+parent=planner

--- a/plugins/affinity-group-processors/host-tag-affinity/src/main/resources/META-INF/cloudstack/host-tag-affinity/spring-host-tag-affinity-context.xml
+++ b/plugins/affinity-group-processors/host-tag-affinity/src/main/resources/META-INF/cloudstack/host-tag-affinity/spring-host-tag-affinity-context.xml
@@ -1,0 +1,37 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                      http://www.springframework.org/schema/beans/spring-beans.xsd
+                      http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+                      http://www.springframework.org/schema/context
+                      http://www.springframework.org/schema/context/spring-context.xsd"
+                      >
+
+    <bean id="HostTagAffinityProcessor"
+        class="org.apache.cloudstack.affinity.HostTagAffinityProcessor">
+        <property name="name" value="HostTagAffinityProcessor" />
+        <property name="type" value="host tag affinity" />
+    </bean>
+
+
+</beans>

--- a/plugins/affinity-group-processors/host-tag-affinity/src/test/java/org/apache/cloudstack/affinity/HostTagAffinityProcessorTest.java
+++ b/plugins/affinity-group-processors/host-tag-affinity/src/test/java/org/apache/cloudstack/affinity/HostTagAffinityProcessorTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cloudstack.affinity;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
+import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloud.deploy.DataCenterDeployment;
+import com.cloud.deploy.DeployDestination;
+import com.cloud.deploy.DeploymentPlanner.ExcludeList;
+import com.cloud.host.Host;
+import com.cloud.host.HostVO;
+import com.cloud.host.dao.HostDao;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.VirtualMachineProfile;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HostTagAffinityProcessorTest {
+
+    @Spy
+    @InjectMocks
+    HostTagAffinityProcessor processor = new HostTagAffinityProcessor();
+
+    @Mock
+    AffinityGroupVMMapDao affinityGroupVMMapDao;
+    @Mock
+    AffinityGroupDao affinityGroupDao;
+    @Mock
+    HostDao hostDao;
+
+    long vmId = 10L;
+    long affinityGroupId = 20L;
+    long zoneId = 2L;
+    long host2Id = 3L;
+    long host3Id = 4L;
+    String groupName = "gold";
+
+    private VirtualMachineProfile mockVmProfile() {
+        VirtualMachine vm = Mockito.mock(VirtualMachine.class);
+        when(vm.getId()).thenReturn(vmId);
+        when(vm.getDataCenterId()).thenReturn(zoneId);
+        VirtualMachineProfile vmProfile = Mockito.mock(VirtualMachineProfile.class);
+        when(vmProfile.getVirtualMachine()).thenReturn(vm);
+        return vmProfile;
+    }
+
+    private void stubGroupMembership() {
+        List<AffinityGroupVMMapVO> vmGroupMappings = new ArrayList<>();
+        vmGroupMappings.add(new AffinityGroupVMMapVO(affinityGroupId, vmId));
+        when(affinityGroupVMMapDao.findByVmIdType(eq(vmId), nullable(String.class))).thenReturn(vmGroupMappings);
+        AffinityGroupVO group = Mockito.mock(AffinityGroupVO.class);
+        when(affinityGroupDao.findById(affinityGroupId)).thenReturn(group);
+        when(group.getName()).thenReturn(groupName);
+    }
+
+    @Test
+    public void testProcessRaisesPriorityForTaggedHosts() {
+        VirtualMachineProfile vmProfile = mockVmProfile();
+        stubGroupMembership();
+
+        HostVO host2 = Mockito.mock(HostVO.class);
+        when(host2.getId()).thenReturn(host2Id);
+        HostVO host3 = Mockito.mock(HostVO.class);
+        when(host3.getId()).thenReturn(host3Id);
+        when(hostDao.listByHostTag(eq(Host.Type.Routing), isNull(), isNull(), eq(zoneId), eq(groupName)))
+                .thenReturn(Arrays.asList(host2, host3));
+
+        DataCenterDeployment plan = new DataCenterDeployment(zoneId);
+        ExcludeList avoid = new ExcludeList();
+
+        processor.process(vmProfile, plan, avoid);
+
+        // Both tagged hosts get raised to priority 1 (DEFAULT 0 -> HIGHER +1); nothing is excluded.
+        Assert.assertEquals(2, plan.getHostPriorities().size());
+        Assert.assertEquals(Integer.valueOf(1), plan.getHostPriorities().get(host2Id));
+        Assert.assertEquals(Integer.valueOf(1), plan.getHostPriorities().get(host3Id));
+        Assert.assertFalse("soft preference: no host may be excluded", avoid.shouldAvoid(host2));
+    }
+
+    @Test
+    public void testProcessNoMatchingHostsIsNoOp() {
+        VirtualMachineProfile vmProfile = mockVmProfile();
+        stubGroupMembership();
+        when(hostDao.listByHostTag(eq(Host.Type.Routing), isNull(), isNull(), eq(zoneId), eq(groupName)))
+                .thenReturn(Collections.emptyList());
+
+        DataCenterDeployment plan = new DataCenterDeployment(zoneId);
+        ExcludeList avoid = new ExcludeList();
+
+        processor.process(vmProfile, plan, avoid);
+
+        Assert.assertTrue(plan.getHostPriorities().isEmpty());
+    }
+
+    @Test
+    public void testCheckAlwaysTrue() throws Exception {
+        // A soft preference must never fail a planned destination.
+        Assert.assertTrue(processor.check(Mockito.mock(VirtualMachineProfile.class), Mockito.mock(DeployDestination.class)));
+    }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -52,6 +52,7 @@
         <module>affinity-group-processors/host-anti-affinity</module>
         <module>affinity-group-processors/non-strict-host-affinity</module>
         <module>affinity-group-processors/non-strict-host-anti-affinity</module>
+        <module>affinity-group-processors/host-tag-affinity</module>
 
         <module>alert-handlers/snmp-alerts</module>
         <module>alert-handlers/syslog-alerts</module>


### PR DESCRIPTION
### Description

Adds a new affinity group processor for a soft host-tag placement preference. A group of type "host tag affinity" uses the group name as a host tag, and when a member VM deploys, hosts in its zone with that tag get a higher deployment priority. It is only a preference: no host is excluded, deployment still works when no tagged host is free, and check() never fails a destination. This is the soft counterpart to the existing strict host tag on service and disk offerings. The raised priority is a planner hint and is not used by automatic DRS.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [x] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Unit tests cover the three paths: tagged hosts get a higher priority, no matching tag is a no-op, and check() returns true.

Also on a live lab with three KVM hosts in one zone: tagged a single host, created a "host tag affinity" group named after the tag, and deployed. All the VMs in the group landed on the tagged host, and a VM outside the group landed on an untagged host.

#### How did you try to break this feature and the system with this change?

Deployed with no host carrying the tag: the processor does nothing and the VM still deploys. Ran a VM outside the group to confirm the untagged host was a valid target, so the tag preference is what steered placement, not a lack of options. Since it only raises priority and never excludes a host, a full or missing tagged host cannot block a deployment.
