### PR TITLE
Skip hypervisors with no systemvm template when creating a shared filesystem

### DIFF
--- a/plugins/storage/sharedfs/storagevm/src/main/java/org/apache/cloudstack/storage/sharedfs/lifecycle/StorageVmSharedFSLifeCycle.java
+++ b/plugins/storage/sharedfs/storagevm/src/main/java/org/apache/cloudstack/storage/sharedfs/lifecycle/StorageVmSharedFSLifeCycle.java
@@ -180,7 +180,10 @@ public class StorageVmSharedFSLifeCycle implements SharedFSLifeCycle {
         for (final Iterator<Hypervisor.HypervisorType> iter = hypervisors.iterator(); iter.hasNext();) {
             final Hypervisor.HypervisorType hypervisor = iter.next();
             VMTemplateVO template = templateDao.findSystemVMReadyTemplate(zoneId, hypervisor, preferredArchitecture);
-            if (template == null && !iter.hasNext()) {
+            if (template == null) {
+                if (iter.hasNext()) {
+                    continue;
+                }
                 throw new CloudRuntimeException(String.format("Unable to find the systemvm template for %s or it was not downloaded in %s.", hypervisor.toString(), zone.toString()));
             }
 

--- a/plugins/storage/sharedfs/storagevm/src/test/java/org/apache/cloudstack/storage/sharedfs/lifecycle/StorageVmSharedFSLifeCycleTest.java
+++ b/plugins/storage/sharedfs/storagevm/src/test/java/org/apache/cloudstack/storage/sharedfs/lifecycle/StorageVmSharedFSLifeCycleTest.java
@@ -53,6 +53,7 @@ import com.cloud.vm.VirtualMachineManager;
 import com.cloud.vm.dao.NicDao;
 import com.cloud.vm.dao.UserVmDao;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.apache.cloudstack.api.ApiCommandResourceType;
@@ -301,6 +302,23 @@ public class StorageVmSharedFSLifeCycleTest {
         DataCenterVO zone = mock(DataCenterVO.class);
         when(dataCenterDao.findById(s_zoneId)).thenReturn(zone);
         when(resourceMgr.getSupportedHypervisorTypes(s_zoneId, false, null)).thenReturn(List.of(Hypervisor.HypervisorType.KVM));
+
+        lifeCycle.deploySharedFS(sharedFS, s_networkId, s_diskOfferingId, s_size, s_minIops, s_maxIops);
+    }
+
+    @Test(expected = CloudRuntimeException.class)
+    public void testDeploySharedFSTemplateNotFoundWithMultipleHypervisors() throws ResourceUnavailableException, InsufficientCapacityException, ResourceAllocationException, IOException, OperationTimedoutException {
+        SharedFS sharedFS = mock(SharedFS.class);
+        when(sharedFS.getDataCenterId()).thenReturn(s_zoneId);
+        when(sharedFS.getName()).thenReturn(s_name);
+        when(sharedFS.getServiceOfferingId()).thenReturn(s_serviceOfferingId);
+        when(sharedFS.getFsType()).thenReturn(SharedFS.FileSystemType.valueOf(s_fsFormat));
+        when(sharedFS.getAccountId()).thenReturn(s_ownerId);
+
+        when(accountMgr.getActiveAccountById(s_ownerId)).thenReturn(null);
+        DataCenterVO zone = mock(DataCenterVO.class);
+        when(dataCenterDao.findById(s_zoneId)).thenReturn(zone);
+        when(resourceMgr.getSupportedHypervisorTypes(s_zoneId, false, null)).thenReturn(new ArrayList<>(List.of(Hypervisor.HypervisorType.KVM, Hypervisor.HypervisorType.VMware)));
 
         lifeCycle.deploySharedFS(sharedFS, s_networkId, s_diskOfferingId, s_size, s_minIops, s_maxIops);
     }


### PR DESCRIPTION
### Description

Creating a shared filesystem fails with a NullPointerException in a zone that has more than one hypervisor type when one of those types has no systemvm template (for example an External or MaaS cluster next to a KVM cluster).

deploySharedFSVM walks the zone's supported hypervisors looking for one with a systemvm template, but it only threw when the template was missing on the last hypervisor. A missing template on any earlier one fell through to template.getId() and hit the NPE. Because the hypervisor list is shuffled, this failed at random.

Now a hypervisor with no template is skipped and the loop moves to the next one, and it only throws when none of them has a template. This mirrors the continue-on-hasNext handling already used for InsufficientCapacityException further down the same loop.

Fixes: #13825

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Added a unit test with two supported hypervisors where neither has a systemvm template. Before this change the deploy throws a NullPointerException, after it throws the intended CloudRuntimeException that says the template was not found. The existing shared filesystem lifecycle tests still pass.

#### How did you try to break this feature and the system with this change?

Checked the single hypervisor case still throws the same not-found error, so there is no regression when only one type is supported. The change only adds a skip to the next hypervisor when a template is missing and never touches the path where a template is found, so a normal deploy is unaffected.
