### PR TITLE
Do not use direct IP allocation for isolated networks with SpecifyIpRanges

### DIFF
--- a/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
+++ b/server/src/main/java/com/cloud/network/guru/GuestNetworkGuru.java
@@ -442,7 +442,7 @@ public abstract class GuestNetworkGuru extends AdapterBase implements NetworkGur
             nic.setIPv4Gateway(network.getGateway());
 
             String guestIp = null;
-            if (network.getSpecifyIpRanges()) {
+            if (GuestType.Shared.equals(network.getGuestType()) && network.getSpecifyIpRanges()) {
                 _ipAddrMgr.allocateDirectIp(nic, dc, vm, network, nic.getRequestedIPv4(), null);
             } else {
                 if (isGateway) {

--- a/server/src/test/java/com/cloud/network/guru/GuestNetworkGuruAllocateTest.java
+++ b/server/src/test/java/com/cloud/network/guru/GuestNetworkGuruAllocateTest.java
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.cloud.network.guru;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cloud.dc.DataCenter;
+import com.cloud.dc.DataCenterVO;
+import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.exception.InsufficientAddressCapacityException;
+import com.cloud.exception.InsufficientVirtualNetworkCapacityException;
+import com.cloud.network.IpAddressManager;
+import com.cloud.network.Network;
+import com.cloud.network.Network.GuestType;
+import com.cloud.network.NetworkModel;
+import com.cloud.network.Networks.TrafficType;
+import com.cloud.network.PhysicalNetwork;
+import com.cloud.offering.NetworkOffering;
+import com.cloud.offerings.dao.NetworkOfferingDao;
+import com.cloud.utils.Pair;
+import com.cloud.vm.NicProfile;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.VirtualMachineProfile;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class GuestNetworkGuruAllocateTest {
+
+    // Minimal concrete guru so the abstract base's allocate() can be exercised directly.
+    public static class TestGuestNetworkGuru extends GuestNetworkGuru {
+        @Override
+        protected boolean canHandle(NetworkOffering offering, DataCenter.NetworkType networkType, PhysicalNetwork physicalNetwork) {
+            return false;
+        }
+    }
+
+    @Mock
+    private DataCenterDao dcDao;
+    @Mock
+    private IpAddressManager ipAddrMgr;
+    @Mock
+    private NetworkModel networkModel;
+    @Mock
+    private NetworkOfferingDao networkOfferingDao;
+
+    @InjectMocks
+    private TestGuestNetworkGuru guru = new TestGuestNetworkGuru();
+
+    private static final long ZONE_ID = 1L;
+    private static final long NETWORK_ID = 100L;
+    private static final long OFFERING_ID = 11L;
+
+    private VirtualMachineProfile userVmProfile() {
+        VirtualMachine vmInstance = Mockito.mock(VirtualMachine.class);
+        when(vmInstance.getType()).thenReturn(VirtualMachine.Type.User);
+        VirtualMachineProfile vm = Mockito.mock(VirtualMachineProfile.class);
+        when(vm.getVirtualMachine()).thenReturn(vmInstance);
+        when(vm.getType()).thenReturn(VirtualMachine.Type.User);
+        return vm;
+    }
+
+    private Network guestNetwork(GuestType guestType) {
+        Network network = Mockito.mock(Network.class);
+        when(network.getTrafficType()).thenReturn(TrafficType.Guest);
+        when(network.getGuestType()).thenReturn(guestType);
+        when(network.getSpecifyIpRanges()).thenReturn(true);
+        when(network.getDataCenterId()).thenReturn(ZONE_ID);
+        when(network.getId()).thenReturn(NETWORK_ID);
+        when(network.getNetworkOfferingId()).thenReturn(OFFERING_ID);
+        when(network.getGateway()).thenReturn("10.0.0.1");
+        return network;
+    }
+
+    @Test
+    public void testAllocateIsolatedWithSpecifyIpRangesUsesNetworkCidrNotDirectIp()
+            throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException {
+        Network network = guestNetwork(GuestType.Isolated);
+        when(network.getCidr()).thenReturn("10.0.0.0/8");
+        VirtualMachineProfile vm = userVmProfile();
+
+        DataCenterVO dc = Mockito.mock(DataCenterVO.class);
+        when(dcDao.findById(ZONE_ID)).thenReturn(dc);
+        when(ipAddrMgr.acquireGuestIpAddress(eq(network), isNull())).thenReturn("10.0.0.5");
+        when(networkModel.getValidNetworkCidr(network)).thenReturn("10.0.0.0/8");
+        when(networkModel.getNetworkIp4Dns(eq(network), eq(dc))).thenReturn(new Pair<>("8.8.8.8", null));
+        when(networkModel.getNextAvailableMacAddressInNetwork(NETWORK_ID)).thenReturn("02:00:00:aa:bb:cc");
+        when(networkOfferingDao.isIpv6Supported(OFFERING_ID)).thenReturn(false);
+
+        NicProfile result = guru.allocate(network, null, vm);
+
+        verify(ipAddrMgr, never()).allocateDirectIp(any(), any(), any(), any(), any(), any());
+        verify(ipAddrMgr).acquireGuestIpAddress(eq(network), isNull());
+        Assert.assertEquals("10.0.0.5", result.getIPv4Address());
+    }
+
+    @Test
+    public void testAllocateSharedWithSpecifyIpRangesUsesDirectIp()
+            throws InsufficientVirtualNetworkCapacityException, InsufficientAddressCapacityException {
+        Network network = guestNetwork(GuestType.Shared);
+        VirtualMachineProfile vm = userVmProfile();
+
+        DataCenterVO dc = Mockito.mock(DataCenterVO.class);
+        when(dcDao.findById(ZONE_ID)).thenReturn(dc);
+        when(networkModel.getNextAvailableMacAddressInNetwork(NETWORK_ID)).thenReturn("02:00:00:aa:bb:cc");
+        when(networkOfferingDao.isIpv6Supported(OFFERING_ID)).thenReturn(false);
+
+        guru.allocate(network, null, vm);
+
+        verify(ipAddrMgr, times(1)).allocateDirectIp(any(), eq(dc), eq(vm), eq(network), isNull(), isNull());
+        verify(ipAddrMgr, never()).acquireGuestIpAddress(any(), any());
+    }
+}


### PR DESCRIPTION
### Description

GuestNetworkGuru.allocate() called allocateDirectIp() for any network that has SpecifyIpRanges set. That path allocates from the zone's VLAN public pools and is only correct for shared networks. An isolated network with SpecifyIpRanges then tried to take an address from the public pools instead of its own CIDR, and failed with InsufficientAddressCapacityException once those pools were exhausted, even though the network's own CIDR still had free addresses.

This gates the direct allocation on the shared guest type, so isolated networks fall through to their normal CIDR allocation. Shared network behaviour is unchanged. This matches the fix suggested by weizhou in the issue.

Fixes: #12772

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Added unit tests on the base guru's allocate(). For an isolated network with SpecifyIpRanges the test checks that allocateDirectIp is not called and the address comes from the network CIDR instead; before this change that test fails because allocateDirectIp is called. For a shared network with SpecifyIpRanges the test checks that allocateDirectIp is still called, so shared allocation is unchanged.

#### How did you try to break this feature and the system with this change?

Kept a shared network test to make sure the direct allocation path is untouched for shared networks. The only behaviour that changes is an isolated network with SpecifyIpRanges, which now uses its own CIDR the same way an isolated network without SpecifyIpRanges already does.
