### PR TITLE
Run the out-of-band management power-state task in a managed context to fix a connection leak

### DIFF
--- a/server/src/main/java/org/apache/cloudstack/outofbandmanagement/PowerOperationTask.java
+++ b/server/src/main/java/org/apache/cloudstack/outofbandmanagement/PowerOperationTask.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.outofbandmanagement;
 
 import org.apache.cloudstack.api.ApiCommandResourceType;
 import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.managed.context.ManagedContextRunnable;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
@@ -27,7 +28,7 @@ import com.cloud.event.EventTypes;
 import com.cloud.event.EventVO;
 import com.cloud.host.Host;
 
-public class PowerOperationTask implements Runnable {
+public class PowerOperationTask extends ManagedContextRunnable {
     protected Logger logger = LogManager.getLogger(getClass());
 
     final private OutOfBandManagementService service;
@@ -46,7 +47,7 @@ public class PowerOperationTask implements Runnable {
     }
 
     @Override
-    public void run() {
+    protected void runInContext() {
         try {
             service.executePowerOperation(host, powerOperation, null);
         } catch (Exception e) {

--- a/server/src/test/java/org/apache/cloudstack/outofbandmanagement/PowerOperationTaskTest.java
+++ b/server/src/test/java/org/apache/cloudstack/outofbandmanagement/PowerOperationTaskTest.java
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.outofbandmanagement;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.cloud.host.Host;
+
+public class PowerOperationTaskTest {
+
+    @Test
+    public void testTaskRunsWithinManagedContextAndExecutesOperation() {
+        OutOfBandManagementService service = mock(OutOfBandManagementService.class);
+        Host host = mock(Host.class);
+        PowerOperationTask task = new PowerOperationTask(service, host, OutOfBandManagement.PowerOperation.STATUS);
+
+        Assert.assertTrue("Background task must run within a managed context so its DB connection is released to the pool",
+                task instanceof ManagedContextRunnable);
+
+        task.run();
+
+        verify(service).executePowerOperation(host, OutOfBandManagement.PowerOperation.STATUS, null);
+    }
+}


### PR DESCRIPTION
### Description

The out-of-band management power-state poll task submits a per-host power status task to a background executor. That task, PowerOperationTask, was a plain Runnable, while the poll task that submits it is a ManagedContextRunnable. Running the per-host work outside a managed context means the database connection its DB work acquires on the worker thread is never released back to the pool. Over time this leaks one connection per configured host on every run, and once the pool reaches maxActive the management server stops serving requests with "Connection is not available, request timed out".

This makes PowerOperationTask a ManagedContextRunnable, matching the poll task that submits it, so the managed context releases the connection when each run finishes.

Fixes: #13382

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Added a unit test that runs the task and checks it is a ManagedContextRunnable and that running it still performs the power operation, so the per-host work now runs inside a managed context and the delegation is unchanged.

#### How did you try to break this feature and the system with this change?

The change only wraps the existing per-host work in a managed context and does not change what it does. The sibling poll task that submits this task already uses the same managed-context base, so the two now behave consistently.
