### PR TITLE
kvm: trim whitespace around backup repository mount options on restore

### DIFF
--- a/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRestoreBackupCommandWrapper.java
+++ b/plugins/hypervisors/kvm/src/main/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRestoreBackupCommandWrapper.java
@@ -211,6 +211,7 @@ public class LibvirtRestoreBackupCommandWrapper extends CommandWrapper<RestoreBa
             mountCmd.add(backupRepoType);
             mountCmd.add(backupRepoAddress);
             mountCmd.add(mountDirectory);
+            mountOptions = normalizeMountOptions(mountOptions);
             if ("cifs".equals(backupRepoType)) {
                 if (StringUtils.isBlank(mountOptions)) {
                     mountOptions = "nobrl";
@@ -228,6 +229,31 @@ public class LibvirtRestoreBackupCommandWrapper extends CommandWrapper<RestoreBa
             throw new CloudRuntimeException("Failed to mount the backup repository on the KVM host");
         }
         return mountDirectory;
+    }
+
+    /**
+     * Removes the whitespace around each option of a comma-separated mount option list.
+     *
+     * mount(8) is handed the list as a single argument and libmount splits it on commas only, so a
+     * blank next to a comma, or at either end of the list, stays glued to the neighbouring option
+     * and is rejected as part of its name or value.
+     *
+     * Only the whitespace around the delimiters is removed. The option text itself is passed
+     * through unchanged, as rejecting unsafe or malformed options belongs to the API layer, not
+     * to the agent.
+     */
+    protected static String normalizeMountOptions(String mountOptions) {
+        if (StringUtils.isBlank(mountOptions)) {
+            return mountOptions;
+        }
+        List<String> options = new ArrayList<>();
+        for (String option : mountOptions.split(",")) {
+            String trimmedOption = option.trim();
+            if (!trimmedOption.isEmpty()) {
+                options.add(trimmedOption);
+            }
+        }
+        return String.join(",", options);
     }
 
     private void unmountBackupDirectory(String backupDirectory) {

--- a/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRestoreBackupCommandWrapperTest.java
+++ b/plugins/hypervisors/kvm/src/test/java/com/cloud/hypervisor/kvm/resource/wrapper/LibvirtRestoreBackupCommandWrapperTest.java
@@ -703,4 +703,79 @@ public class LibvirtRestoreBackupCommandWrapperTest {
         Assert.assertFalse(args.stream().anyMatch(arg -> arg.contains("EOF")));
         Assert.assertTrue(args.get(args.size() - 1).endsWith(".xml"));
     }
+
+    private String[] captureMountCommand(String backupRepoType, String mountOptions) throws Exception {
+        Method method = LibvirtRestoreBackupCommandWrapper.class.getDeclaredMethod("mountBackupDirectory",
+                String.class, String.class, String.class, Integer.class);
+        method.setAccessible(true);
+
+        final String[][] captured = new String[1][];
+        try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
+            Path tempPath = Mockito.mock(Path.class);
+            when(tempPath.toString()).thenReturn("/tmp/csbackup.abc123");
+            filesMock.when(() -> Files.createTempDirectory(anyString())).thenReturn(tempPath);
+
+            try (MockedStatic<Script> scriptMock = mockStatic(Script.class)) {
+                scriptMock.when(() -> Script.getExecutableAbsolutePath(anyString()))
+                        .thenAnswer(invocation -> invocation.getArgument(0));
+                scriptMock.when(() -> Script.executeCommand(any(String[].class)))
+                        .thenAnswer(invocation -> {
+                            // Mockito expands varargs, so the command comes back as individual arguments.
+                            captured[0] = Arrays.stream(invocation.getArguments()).map(String::valueOf).toArray(String[]::new);
+                            return "";
+                        });
+                method.invoke(wrapper, "10.0.0.1:/export/backup", backupRepoType, mountOptions, 30);
+            }
+        }
+        return captured[0];
+    }
+
+    private String getMountOptions(String[] mountCmd) {
+        List<String> args = Arrays.asList(mountCmd);
+        int index = args.indexOf("-o");
+        return index < 0 ? null : args.get(index + 1);
+    }
+
+    @Test
+    public void testMountTrimsTrailingWhitespaceFromMountOptions() throws Exception {
+        // A repository saved with "vers=4.1 " reaches mount as a single argument and libmount splits
+        // it on commas only, so the blank would stay glued to the option and be rejected.
+        Assert.assertEquals("vers=4.1", getMountOptions(captureMountCommand("nfs", "vers=4.1 ")));
+    }
+
+    @Test
+    public void testMountTrimsWhitespaceAroundEveryOption() throws Exception {
+        Assert.assertEquals("vers=4.1,soft", getMountOptions(captureMountCommand("nfs", " vers=4.1 , soft ")));
+    }
+
+    @Test
+    public void testMountDropsEmptyMountOptions() throws Exception {
+        Assert.assertEquals("vers=4.1,soft", getMountOptions(captureMountCommand("nfs", "vers=4.1,,soft")));
+    }
+
+    @Test
+    public void testMountDoesNotStripWhitespaceInsideAnOption() throws Exception {
+        // Only the blanks around the delimiters are removed. Whether an option is well formed is
+        // decided when the repository is saved, so the agent passes the text itself through as is
+        // rather than silently rewriting a stored value.
+        Assert.assertEquals("username=some user,nobrl",
+                getMountOptions(captureMountCommand("cifs", "username=some user")));
+    }
+
+    @Test
+    public void testMountAppendsNobrlAfterTrimmingCifsOptions() throws Exception {
+        // nobrl is appended to the list, so the blank has to go first, otherwise it ends up in the
+        // middle of the list where libmount cannot ignore it either.
+        Assert.assertEquals("vers=3.0,nobrl", getMountOptions(captureMountCommand("cifs", "vers=3.0 ")));
+    }
+
+    @Test
+    public void testMountOmitsMountOptionsThatAreOnlyWhitespace() throws Exception {
+        Assert.assertNull(getMountOptions(captureMountCommand("nfs", "   ")));
+    }
+
+    @Test
+    public void testMountFallsBackToNobrlWhenCifsOptionsAreOnlyWhitespace() throws Exception {
+        Assert.assertEquals("nobrl", getMountOptions(captureMountCommand("cifs", "   ")));
+    }
 }


### PR DESCRIPTION
### Description

Fixes #14013

A backup repository whose mount options carry stray whitespace, for example `vers=4.1 `,
backs up fine but fails to restore:

    mount.nfs: an incorrect mount option was specified for
    /usr/share/cloudstack-agent/tmp/csbackup...

`LibvirtRestoreBackupCommandWrapper.mountBackupDirectory` builds the mount command as an argv
list and runs it without a shell:

    if (StringUtils.isNotBlank(mountOptions)) {
        mountCmd.add("-o");
        mountCmd.add(mountOptions);
    }
    Script.executeCommand(mountCmd.toArray(new String[0]));

`Script.executeCommand(String...)` hands each element to `ProcessBuilder` verbatim, so mount
receives the literal option list `vers=4.1 `. libmount splits that list on commas only, so the
blank stays glued to the last option and the kernel rejects it as part of the option value.

Backup, delete and stats do not hit this today because they pass the options to `nasbackup.sh`,
which expands them unquoted:

    mount -t ${NAS_TYPE} ${NAS_ADDRESS} ${mount_point} $([[ ! -z "${MOUNT_OPTS}" ]] && echo -o ${MOUNT_OPTS})

Shell word splitting drops the blank there, which is why restore is the only operation that
fails: it is the only one of the four that builds the mount command in Java.

Fixed by normalising the option list before it is used. Each comma-separated option is trimmed
and empty ones are dropped. Only the whitespace around the delimiters is removed; the option
text itself is passed through unchanged, since deciding whether an option is well formed
belongs to the API layer rather than the agent.

The normalisation happens **before** the cifs branch appends `,nobrl`. Trimming afterwards
would leave `vers=3.0 ,nobrl`, moving the blank into the middle of the list where libmount
cannot ignore it either.

#### Relationship to #14009

#14009 stops this class of value from being stored: it rejects whitespace per option in
`AddBackupRepositoryCmd` / `UpdateBackupRepositoryCmd`, and it quotes `"${MOUNT_OPTS}"` in
`nasbackup.sh`. That is the right place for validation and I have deliberately not duplicated
any of it here — the two changes touch no common files.

They are complementary rather than alternatives, because #14009 validates on the way in and
cannot clean rows that are already in the database. On an existing deployment such as the one
in #14013, the stored `vers=4.1 ` survives, and once `MOUNT_OPTS` is quoted it will break the
script-based operations too, not just restore. Normalising at the point of use fixes those
repositories without a schema migration.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [x] Minor

### How Has This Been Tested?

Added seven unit tests to `LibvirtRestoreBackupCommandWrapperTest` that invoke
`mountBackupDirectory` and assert on the exact `-o` argument handed to `mount`:

| mount options | repo type | `-o` argument | fails without the fix |
| --- | --- | --- | --- |
| `vers=4.1 ` | nfs | `vers=4.1` | yes |
| ` vers=4.1 , soft ` | nfs | `vers=4.1,soft` | yes |
| `vers=4.1,,soft` | nfs | `vers=4.1,soft` | yes |
| `vers=3.0 ` | cifs | `vers=3.0,nobrl` | yes |
| `username=some user` | cifs | `username=some user,nobrl` | no |
| `   ` | nfs | no `-o` at all | no |
| `   ` | cifs | `nobrl` | no |

The last three already hold today. They are there to pin behaviour the fix must not change:
that trimming is scoped to the delimiters rather than stripping whitespace throughout, and
that an all-whitespace value still collapses to no options at all (or to bare `nobrl` for
cifs) instead of becoming an empty option.

    mvn test -pl plugins/hypervisors/kvm -Dtest=LibvirtRestoreBackupCommandWrapperTest
    Tests run: 24, Failures: 0, Errors: 0, Skipped: 0

Removing just the `normalizeMountOptions` call and rerunning gives 4 failures, each showing
the blank that mount rejects:

    expected:<vers=4.1[]>        but was:<vers=4.1[ ]>
    expected:<[vers=4.1,soft]>   but was:<[ vers=4.1 , soft ]>
    expected:<vers=4.1,[]soft>   but was:<vers=4.1,[,]soft>
    expected:<vers=3.0[],nobrl>  but was:<vers=3.0[ ],nobrl>

The last of those is the ordering point: the blank lands in the middle of the list once
`nobrl` is appended after it.

I do not have a KVM zone with a NAS repository available, so this is unit-level only; the
mount argument that the kernel rejects is asserted directly rather than end to end.

The same construction is present on 4.20. I targeted 4.22 because that is the version the
issue is reported against, but happy to retarget if it should land on 4.20 first.
