### PR TITLE
Fix NPE if on port 8096 getUserKeys

### DIFF
--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -3315,15 +3315,14 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
         verifyCallerPrivilegeForUserOrAccountOperations(user);
 
         String accessingApiKey = getAccessingApiKey(cmd);
-        ApiKeyPair keyPair;
+        ApiKeyPair keyPair = null;
         if (accessingApiKey != null) {
             ApiKeyPair accessingKeyPair = apiKeyPairService.findByApiKey(accessingApiKey);
-            if (userId == accessingKeyPair.getUserId()) {
-                keyPair = apiKeyPairService.findByApiKey(accessingApiKey);
-            } else {
-                keyPair = _accountService.getLatestUserKeyPair(userId);
+            if (accessingKeyPair != null && userId == accessingKeyPair.getUserId()) {
+                keyPair = accessingKeyPair;
             }
-        } else {
+        }
+        if (keyPair == null) {
             keyPair = _accountService.getLatestUserKeyPair(userId);
         }
 
@@ -3436,6 +3435,10 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             return Boolean.TRUE;
         }
         ApiKeyPair accessingKeyPair = apiKeyPairService.findByApiKey(apiKey);
+        if (accessingKeyPair == null) {
+            logger.info("Unable to find the API key pair used to access the API; therefore, its permissions cannot be verified.");
+            return Boolean.FALSE;
+        }
         return isApiKeySupersetOfPermission(new ArrayList<>(getAllKeypairPermissions(accessingKeyPair.getApiKey())), new ArrayList<>(getAllKeypairPermissions(accessedKeyPair.getApiKey())));
     }
 
@@ -3454,7 +3457,7 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
                 String apiKey = requestPayload.entrySet().stream()
                         .filter(e -> ApiConstants.API_KEY.equalsIgnoreCase(e.getKey()))
                         .map(Map.Entry::getValue).findFirst().orElse(null);
-                if (apiKey != null) {
+                if (apiKey != null && isApiKeyOwnedByCallingUser(apiKey)) {
                     logger.info("Request's API key is [{}].", apiKey);
                     return apiKey;
                 }
@@ -3465,6 +3468,35 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
 
         logger.info("Request's signature or API key were not identified; assuming it has been authenticated via session.");
         return null;
+    }
+
+    /**
+     * Checks whether the API key present in the request belongs to the calling user. When a request is authenticated through
+     * an API key pair, the calling user is always the owner of that key pair, so a request whose API key does not map to a
+     * key pair of the calling user was not authenticated through it.
+     * <p>
+     * Requests sent to the integration API port (see {@code integration.api.port}) are not signature-checked and run under the
+     * system user, so any API key and signature they carry are ignored and the caller's role permissions apply instead.
+     * For any other caller such a request is rejected: on the regular API port the signature is only verified when there is no
+     * authenticated session, so a mismatching API key can only be the result of a tampered request, and honoring it would
+     * derive permissions from a key pair that the caller did not prove ownership of.
+     *
+     * @throws PermissionDeniedException if the calling user is not the system user and the API key does not belong to them.
+     */
+    protected boolean isApiKeyOwnedByCallingUser(String apiKey) {
+        long callingUserId = CallContext.current().getCallingUserId();
+        ApiKeyPair keyPair = apiKeyPairService.findByApiKey(apiKey);
+        if (keyPair != null && Long.valueOf(callingUserId).equals(keyPair.getUserId())) {
+            return true;
+        }
+        String keyPairDescription = keyPair == null ? "an API key that does not map to any API key pair" :
+                String.format("API key pair [%s] which belongs to user with ID [%s]", keyPair.getUuid(), keyPair.getUserId());
+        if (callingUserId == User.UID_SYSTEM) {
+            logger.debug("Request made by the system user (e.g. through the integration API port) contains {}; ignoring it.", keyPairDescription);
+            return false;
+        }
+        logger.warn("Request made by user with ID [{}] contains {}; rejecting the request.", callingUserId, keyPairDescription);
+        throw new PermissionDeniedException("The API key present in the request does not belong to the calling user.");
     }
 
     private Boolean isApiKeySupersetOfPermission(List<RolePermissionEntity> baseKeyPairPermissions, List<RolePermissionEntity> comparedPermissions) {
@@ -3727,6 +3759,9 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
             throw new InvalidParameterValueException("API key not present in the request's URL and, thus, unable to fetch API key rules.");
         }
         ApiKeyPair apiKeyPair = keyPairManager.findByApiKey(apiKey);
+        if (apiKeyPair == null) {
+            throw new InvalidParameterValueException("Unable to find an API key pair matching the API key present in the request's URL and, thus, unable to fetch API key rules.");
+        }
         Account account = _accountDao.findById(apiKeyPair.getAccountId());
         List<ApiKeyPairPermission> keyPairPermissions = keyPairManager.findAllPermissionsByKeyPairId(apiKeyPair.getId(), account.getRoleId());
         return new ArrayList<>(keyPairPermissions);

--- a/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
+++ b/server/src/test/java/com/cloud/user/AccountManagerImplTest.java
@@ -2289,4 +2289,100 @@ public class AccountManagerImplTest extends AccountManagentImplTestBase {
 
         accountManagerImpl.checkRoleEscalation(caller, requested);
     }
+
+    private Map<String, String> buildSignedRequestParams(String apiKey) {
+        Map<String, String> params = new HashMap<>();
+        params.put(ApiConstants.API_KEY, apiKey);
+        params.put(ApiConstants.SIGNATURE, "signature");
+        return params;
+    }
+
+    @Test
+    public void getAccessingApiKeyTestReturnsApiKeyWhenKeyPairBelongsToCallingUser() {
+        Mockito.when(callingUser.getId()).thenReturn(111L);
+        CallContext.register(callingUser, callingAccount);
+        Mockito.when(_getkeyscmd.getFullUrlParams()).thenReturn(buildSignedRequestParams("api-key"));
+        Mockito.when(apiKeyPairVOMock.getUserId()).thenReturn(111L);
+        Mockito.when(apiKeyPairService.findByApiKey("api-key")).thenReturn(apiKeyPairVOMock);
+
+        Assert.assertEquals("api-key", accountManagerImpl.getAccessingApiKey(_getkeyscmd));
+    }
+
+    @Test(expected = PermissionDeniedException.class)
+    public void getAccessingApiKeyTestThrowsWhenKeyPairBelongsToAnotherUser() {
+        Mockito.when(callingUser.getId()).thenReturn(111L);
+        CallContext.register(callingUser, callingAccount);
+        Mockito.when(_getkeyscmd.getFullUrlParams()).thenReturn(buildSignedRequestParams("api-key"));
+        Mockito.when(apiKeyPairVOMock.getUserId()).thenReturn(222L);
+        Mockito.when(apiKeyPairService.findByApiKey("api-key")).thenReturn(apiKeyPairVOMock);
+
+        accountManagerImpl.getAccessingApiKey(_getkeyscmd);
+    }
+
+    @Test(expected = PermissionDeniedException.class)
+    public void getAccessingApiKeyTestThrowsWhenKeyPairDoesNotExist() {
+        Mockito.when(callingUser.getId()).thenReturn(111L);
+        CallContext.register(callingUser, callingAccount);
+        Mockito.when(_getkeyscmd.getFullUrlParams()).thenReturn(buildSignedRequestParams("dummy"));
+        Mockito.when(apiKeyPairService.findByApiKey("dummy")).thenReturn(null);
+
+        accountManagerImpl.getAccessingApiKey(_getkeyscmd);
+    }
+
+    @Test
+    public void getAccessingApiKeyTestReturnsNullWhenKeyPairBelongsToAnotherUserAndCallerIsSystemUser() {
+        Mockito.when(callingUser.getId()).thenReturn(User.UID_SYSTEM);
+        CallContext.register(callingUser, callingAccount);
+        Mockito.when(_getkeyscmd.getFullUrlParams()).thenReturn(buildSignedRequestParams("api-key"));
+        Mockito.when(apiKeyPairVOMock.getUserId()).thenReturn(222L);
+        Mockito.when(apiKeyPairService.findByApiKey("api-key")).thenReturn(apiKeyPairVOMock);
+
+        Assert.assertNull(accountManagerImpl.getAccessingApiKey(_getkeyscmd));
+    }
+
+    @Test
+    public void getAccessingApiKeyTestReturnsNullWhenKeyPairDoesNotExistAndCallerIsSystemUser() {
+        Mockito.when(callingUser.getId()).thenReturn(User.UID_SYSTEM);
+        CallContext.register(callingUser, callingAccount);
+        Mockito.when(_getkeyscmd.getFullUrlParams()).thenReturn(buildSignedRequestParams("dummy"));
+        Mockito.when(apiKeyPairService.findByApiKey("dummy")).thenReturn(null);
+
+        Assert.assertNull(accountManagerImpl.getAccessingApiKey(_getkeyscmd));
+    }
+
+    @Test
+    public void getAccessingApiKeyTestReturnsNullWhenRequestIsNotSigned() {
+        Map<String, String> params = new HashMap<>();
+        params.put(ApiConstants.API_KEY, "api-key");
+        Mockito.when(_getkeyscmd.getFullUrlParams()).thenReturn(params);
+
+        Assert.assertNull(accountManagerImpl.getAccessingApiKey(_getkeyscmd));
+        Mockito.verify(apiKeyPairService, Mockito.never()).findByApiKey(Mockito.anyString());
+    }
+
+    @Test
+    public void getKeysTestReturnsLatestKeyPairWhenRequestApiKeyIsNotVerified() {
+        // Requests through the integration API port run as the system user and are not signature-checked, so the
+        // API key and signature they may carry must not be used to derive permissions.
+        Mockito.when(callingUser.getId()).thenReturn(User.UID_SYSTEM);
+        CallContext.register(callingUser, callingAccount);
+        long userId = 2L;
+        Mockito.when(_getkeyscmd.getId()).thenReturn(userId);
+        Mockito.when(_getkeyscmd.getFullUrlParams()).thenReturn(buildSignedRequestParams("dummy"));
+        Mockito.doReturn(userVoMock).when(accountManagerImpl).getActiveUser(userId);
+        Mockito.when(userVoMock.getApiKeyAccess()).thenReturn(Boolean.TRUE);
+        Mockito.when(_accountDao.findByIdIncludingRemoved(accountMockId)).thenReturn(callingAccount);
+        Mockito.doNothing().when(accountManagerImpl).checkAccess(Mockito.any(User.class), Mockito.any(ControlledEntity.class));
+        Mockito.doNothing().when(accountManagerImpl).verifyCallerPrivilegeForUserOrAccountOperations(Mockito.any(User.class));
+        Mockito.when(apiKeyPairService.findByApiKey("dummy")).thenReturn(null);
+        Mockito.when(apiKeyPairVOMock.getApiKey()).thenReturn("latest-api-key");
+        Mockito.when(apiKeyPairVOMock.getSecretKey()).thenReturn("latest-secret-key");
+        Mockito.when(_accountService.getLatestUserKeyPair(userId)).thenReturn(apiKeyPairVOMock);
+
+        Pair<Boolean, Map<String, String>> result = accountManagerImpl.getKeys(_getkeyscmd);
+
+        Assert.assertTrue(result.first());
+        Assert.assertEquals("latest-api-key", result.second().get("apikey"));
+        Assert.assertEquals("latest-secret-key", result.second().get("secretkey"));
+    }
 }


### PR DESCRIPTION
### Description
We used to use port 8096 to access admin api keys in a cloudstack simulator testing setup for ansible. But this stopped working with an NPE since 4.22. I think. I am not sure if this is the correct fix but leaving it for testing and feedback. it's kind of an edge case.

This is what we do:

Install cs cloudstack cli client

```
$ pip install cs
```
configure dummy login, 8096 does not need a real secret/key but the cli want one

```
$ export CLOUDSTACK_ENDPOINT=http://127.0.0.1:8096
$ export CLOUDSTACK_SECRET=dummy
$ export CLOUDSTACK_KEY=dummy
```

query user id of admin account

```
$ admin_id="$(cs listUsers account=admin | jq '.user[0].id')"
$ echo $admin_id 
"3988a617-a622-11f1-a89d-ee147cfcbd84"
```

try to get api keys of admin user using its user id

```
$ cs getUserKeys id=$admin_id 
CloudStack error: HTTP 530 response from CloudStack
{
  "getuserkeysresponse": {
    "cserrorcode": 9999,
    "errorcode": 530,
    "errortext": "Cannot invoke \"org.apache.cloudstack.acl.apikeypair.ApiKeyPair.getUserId()\" because \"accessingKeyPair\" is null",
    "uuidList": []
  }
}
```

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

Preparing for testing.