### PR TITLE
network: skip dhcp and dns health checks on internal LB routers

### DIFF
--- a/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/router/VirtualNetworkApplianceManagerImpl.java
@@ -276,6 +276,7 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
     private static final String FILESYSTEM_WRITABLE_TEST = "filesystem.writable.test";
     private static final String READONLY_FILESYSTEM_ERROR = "Read-only file system";
     private static final String BACKUP_ROUTER_EXCLUDED_TESTS = "gateways_check.py";
+    private static final String INTERNAL_LB_EXCLUDED_TESTS = "dhcp_check.py,dns_check.py";
     /**
      * Used regex to ensure that the value that will be passed to the VR is an acceptable value
      */
@@ -1615,6 +1616,9 @@ Configurable, StateListener<VirtualMachine.State, VirtualMachine.Event, VirtualM
                     routerGuestNtwkIds == null || routerGuestNtwkIds.isEmpty()) {
                 excludedTests = excludedTests.isEmpty() ? BACKUP_ROUTER_EXCLUDED_TESTS : excludedTests + "," + BACKUP_ROUTER_EXCLUDED_TESTS;
             }
+        }
+        if (router.getRole() == Role.INTERNAL_LB_VM) {
+            excludedTests = excludedTests.isEmpty() ? INTERNAL_LB_EXCLUDED_TESTS : excludedTests + "," + INTERNAL_LB_EXCLUDED_TESTS;
         }
 
         command.setAccessDetail(SetMonitorServiceCommand.ROUTER_HEALTH_CHECKS_EXCLUDED, excludedTests);

--- a/server/src/test/java/com/cloud/network/router/VirtualNetworkApplianceManagerImplTest.java
+++ b/server/src/test/java/com/cloud/network/router/VirtualNetworkApplianceManagerImplTest.java
@@ -67,6 +67,7 @@ import com.cloud.storage.dao.VolumeDao;
 import com.cloud.user.dao.UserDao;
 import com.cloud.user.dao.UserStatisticsDao;
 import com.cloud.user.dao.UserStatsLogDao;
+import com.cloud.agent.api.routing.SetMonitorServiceCommand;
 import com.cloud.vm.DomainRouterVO;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineManager;
@@ -91,6 +92,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -352,6 +354,28 @@ public class VirtualNetworkApplianceManagerImplTest {
         foo = "*:*:00";
         result = virtualNetworkApplianceManagerImpl.checkLogrotateTimerPattern(foo);
         Assert.assertTrue(result);
+    }
+
+    @Test
+    public void testInternalLbRouterExcludesDhcpAndDnsHealthChecks() throws Exception {
+        DomainRouterVO router = Mockito.mock(DomainRouterVO.class);
+        when(router.getId()).thenReturn(1L);
+        when(router.getInstanceName()).thenReturn("r-1-VM");
+        when(router.getDataCenterId()).thenReturn(1L);
+        when(router.getIsRedundantRouter()).thenReturn(false);
+        when(router.getRole()).thenReturn(VirtualRouter.Role.INTERNAL_LB_VM);
+        when(_routerControlHelper.getRouterControlIp(1L)).thenReturn("169.254.0.1");
+
+        java.lang.reflect.Method method = VirtualNetworkApplianceManagerImpl.class.getDeclaredMethod(
+                "createMonitorServiceCommand", DomainRouterVO.class, List.class, boolean.class, boolean.class, Map.class);
+        method.setAccessible(true);
+        SetMonitorServiceCommand command = (SetMonitorServiceCommand) method.invoke(
+                virtualNetworkApplianceManagerImpl, router, null, true, true, null);
+
+        String excluded = command.getAccessDetail(SetMonitorServiceCommand.ROUTER_HEALTH_CHECKS_EXCLUDED);
+        Assert.assertNotNull(excluded);
+        Assert.assertTrue("Internal LB VM should exclude dhcp and dns health checks, got: " + excluded,
+                excluded.contains("dhcp_check.py") && excluded.contains("dns_check.py"));
     }
 
     @Test


### PR DESCRIPTION
### Description

An internal LB VM runs only the load balancer, but it is configured with the full virtual router health check set. The dhcp and dns checks have nothing to verify on an internal LB, so they fail on every advanced health check run and flood the event log with failures every few minutes.

This excludes the dhcp and dns checks for a router whose role is internal LB, using the existing per-router excluded-checks mechanism (the same one that already excludes the gateway check on backup routers).

Fixes: #12658

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Added a unit test on createMonitorServiceCommand: for a router whose role is internal LB, the excluded health checks now include dhcp_check.py and dns_check.py. Before this change the excluded set is empty for that router and the test fails. The existing appliance-manager tests still pass.

#### How did you try to break this feature and the system with this change?

The exclusion is gated on the internal LB role, so a normal virtual router or VPC router is unaffected. The change only appends to the existing excluded-checks list, alongside the backup-router gateway-check exclusion that is already there.
