### PR TITLE
DRS: honour anti-affinity when planning and executing migrations

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/affinity/AffinityProcessorBase.java
+++ b/api/src/main/java/org/apache/cloudstack/affinity/AffinityProcessorBase.java
@@ -25,7 +25,9 @@ import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineProfile;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class AffinityProcessorBase extends AdapterBase implements AffinityGroupProcessor {
 
@@ -39,6 +41,23 @@ public class AffinityProcessorBase extends AdapterBase implements AffinityGroupP
     @Override
     public void process(VirtualMachineProfile vm, DeploymentPlan plan, ExcludeList avoid, List<VirtualMachine> vmList) throws AffinityConflictException {
 
+    }
+
+
+    /**
+     * Indexes placements supplied by the caller. Callers such as DRS build a plan of several moves
+     * in memory and persist it only at the end, so during planning the database still shows the old
+     * host for every VM the plan has already moved.
+     */
+    protected Map<Long, VirtualMachine> getVmIdVmMap(List<VirtualMachine> vmList) {
+        Map<Long, VirtualMachine> vmIdVmMap = new HashMap<>();
+        if (vmList == null) {
+            return vmIdVmMap;
+        }
+        for (VirtualMachine vm : vmList) {
+            vmIdVmMap.put(vm.getId(), vm);
+        }
+        return vmIdVmMap;
     }
 
     @Override

--- a/plugins/affinity-group-processors/host-anti-affinity/src/main/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessor.java
+++ b/plugins/affinity-group-processors/host-anti-affinity/src/main/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessor.java
@@ -59,7 +59,7 @@ public class HostAntiAffinityProcessor extends AffinityProcessorBase implements 
     protected AffinityGroupDao _affinityGroupDao;
     @Inject
     protected AffinityGroupVMMapDao _affinityGroupVMMapDao;
-    private int _vmCapacityReleaseInterval;
+    protected int _vmCapacityReleaseInterval;
     @Inject
     protected ConfigurationDao _configDao;
 
@@ -102,22 +102,24 @@ public class HostAntiAffinityProcessor extends AffinityProcessorBase implements 
 
             for (Long groupVMId : groupVMIds) {
                 VMInstanceVO groupVM = _vmInstanceDao.findById(groupVMId);
-                if (groupVM != null && !groupVM.isRemoved()) {
-                    if (groupVM.getHostId() != null) {
-                        avoid.addHost(groupVM.getHostId());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Added host {} to avoid set, since VM {} is present on the host", groupVM.getHostId(), groupVM);
-                        }
-                    }
-                } else if (Arrays.asList(VirtualMachine.State.Starting, VirtualMachine.State.Stopped).contains(groupVM.getState()) && groupVM.getLastHostId() != null) {
-                    long secondsSinceLastUpdate = (DateUtil.currentGMTTime().getTime() - groupVM.getUpdateTime().getTime()) / 1000;
-                    if (secondsSinceLastUpdate < _vmCapacityReleaseInterval) {
-                        avoid.addHost(groupVM.getLastHostId());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Added host {} to avoid set, since VM {} is present on the host, in Stopped state but has reserved capacity", groupVM.getLastHostId(), groupVM);
-                        }
-                    }
+                if (groupVM == null || groupVM.isRemoved()) {
+                    continue;
                 }
+                avoidHostOfVmInAffinityGroup(avoid, groupVM);
+            }
+        }
+    }
+
+    protected void avoidHostOfVmInAffinityGroup(ExcludeList avoid, VMInstanceVO groupVM) {
+        if (groupVM.getHostId() != null) {
+            avoid.addHost(groupVM.getHostId());
+            logger.debug("Added host {} to avoid set, since VM {} is present on the host", groupVM.getHostId(), groupVM);
+        } else if (Arrays.asList(VirtualMachine.State.Starting, VirtualMachine.State.Stopped).contains(groupVM.getState()) && groupVM.getLastHostId() != null) {
+            long secondsSinceLastUpdate = (DateUtil.currentGMTTime().getTime() - groupVM.getUpdateTime().getTime()) / 1000;
+            if (secondsSinceLastUpdate < _vmCapacityReleaseInterval) {
+                avoid.addHost(groupVM.getLastHostId());
+                logger.debug("Added host {} to avoid set, since VM {} is in {} state on the host but still has reserved capacity",
+                        groupVM.getLastHostId(), groupVM, groupVM.getState());
             }
         }
     }

--- a/plugins/affinity-group-processors/host-anti-affinity/src/main/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessor.java
+++ b/plugins/affinity-group-processors/host-anti-affinity/src/main/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessor.java
@@ -18,7 +18,6 @@ package org.apache.cloudstack.affinity;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -131,14 +130,6 @@ public class HostAntiAffinityProcessor extends AffinityProcessorBase implements 
                 avoidHostOfVmInAffinityGroup(avoid, groupVM);
             }
         }
-    }
-
-    protected Map<Long, VirtualMachine> getVmIdVmMap(List<VirtualMachine> vmList) {
-        Map<Long, VirtualMachine> vmIdVmMap = new HashMap<>();
-        for (VirtualMachine vm : vmList) {
-            vmIdVmMap.put(vm.getId(), vm);
-        }
-        return vmIdVmMap;
     }
 
     protected void avoidHostOfVmInAffinityGroup(ExcludeList avoid, VMInstanceVO groupVM) {

--- a/plugins/affinity-group-processors/host-anti-affinity/src/main/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessor.java
+++ b/plugins/affinity-group-processors/host-anti-affinity/src/main/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessor.java
@@ -17,6 +17,8 @@
 package org.apache.cloudstack.affinity;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -82,7 +84,7 @@ public class HostAntiAffinityProcessor extends AffinityProcessorBase implements 
                     _affinityGroupDao.listByIds(affinityGroupIds, true);
                 }
                 for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
-                    processAffinityGroup(vmGroupMapping, avoid, vm);
+                    processAffinityGroup(vmGroupMapping, avoid, vm, vmList);
                 }
             }
         });
@@ -90,6 +92,18 @@ public class HostAntiAffinityProcessor extends AffinityProcessorBase implements 
     }
 
     protected void processAffinityGroup(AffinityGroupVMMapVO vmGroupMapping, ExcludeList avoid, VirtualMachine vm) {
+        processAffinityGroup(vmGroupMapping, avoid, vm, Collections.emptyList());
+    }
+
+    /**
+     * Applies anti-affinity for one group.
+     *
+     * @param vmList
+     *         placements to honour in preference to what the database says. DRS builds a plan of
+     *         several migrations in memory and only persists it later, so during plan generation
+     *         the database still shows the old host for every VM the plan has already moved.
+     */
+    protected void processAffinityGroup(AffinityGroupVMMapVO vmGroupMapping, ExcludeList avoid, VirtualMachine vm, List<VirtualMachine> vmList) {
         if (vmGroupMapping != null) {
             AffinityGroupVO group = _affinityGroupDao.findById(vmGroupMapping.getAffinityGroupId());
 
@@ -100,7 +114,16 @@ public class HostAntiAffinityProcessor extends AffinityProcessorBase implements 
             List<Long> groupVMIds = _affinityGroupVMMapDao.listVmIdsByAffinityGroup(group.getId());
             groupVMIds.remove(vm.getId());
 
+            Map<Long, VirtualMachine> plannedVms = getVmIdVmMap(vmList);
+
             for (Long groupVMId : groupVMIds) {
+                VirtualMachine plannedVm = plannedVms.get(groupVMId);
+                if (plannedVm != null && plannedVm.getHostId() != null) {
+                    avoid.addHost(plannedVm.getHostId());
+                    logger.debug("Added host {} to avoid set, since VM {} is placed on the host by the plan being built",
+                            plannedVm.getHostId(), plannedVm);
+                    continue;
+                }
                 VMInstanceVO groupVM = _vmInstanceDao.findById(groupVMId);
                 if (groupVM == null || groupVM.isRemoved()) {
                     continue;
@@ -108,6 +131,14 @@ public class HostAntiAffinityProcessor extends AffinityProcessorBase implements 
                 avoidHostOfVmInAffinityGroup(avoid, groupVM);
             }
         }
+    }
+
+    protected Map<Long, VirtualMachine> getVmIdVmMap(List<VirtualMachine> vmList) {
+        Map<Long, VirtualMachine> vmIdVmMap = new HashMap<>();
+        for (VirtualMachine vm : vmList) {
+            vmIdVmMap.put(vm.getId(), vm);
+        }
+        return vmIdVmMap;
     }
 
     protected void avoidHostOfVmInAffinityGroup(ExcludeList avoid, VMInstanceVO groupVM) {

--- a/plugins/affinity-group-processors/host-anti-affinity/src/test/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessorTest.java
+++ b/plugins/affinity-group-processors/host-anti-affinity/src/test/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessorTest.java
@@ -34,6 +34,7 @@ import org.mockito.Spy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -49,6 +50,7 @@ public class HostAntiAffinityProcessorTest {
     private static final long GROUP_VM_ID = 1L;
     private static final long HOST_ID = 10L;
     private static final long LAST_HOST_ID = 11L;
+    private static final long PLANNED_HOST_ID = 12L;
     private static final int CAPACITY_RELEASE_INTERVAL = 3600;
 
     @Mock
@@ -153,6 +155,49 @@ public class HostAntiAffinityProcessorTest {
         processor.processAffinityGroup(vmGroupMapping, avoid, vm);
 
         assertFalse(avoids(HOST_ID));
+    }
+
+    @Test
+    public void testPlannedHostWinsOverStaleDatabaseHost() {
+        VMInstanceVO plannedVm = org.mockito.Mockito.mock(VMInstanceVO.class);
+        when(plannedVm.getId()).thenReturn(GROUP_VM_ID);
+        when(plannedVm.getHostId()).thenReturn(PLANNED_HOST_ID);
+
+        // the database still shows the pre-migration host
+        when(_vmInstanceDao.findById(GROUP_VM_ID)).thenReturn(groupVM);
+        when(groupVM.isRemoved()).thenReturn(false);
+        when(groupVM.getHostId()).thenReturn(HOST_ID);
+
+        processor.processAffinityGroup(vmGroupMapping, avoid, vm, Arrays.asList(plannedVm));
+
+        assertTrue(avoids(PLANNED_HOST_ID));
+        assertFalse(avoids(HOST_ID));
+    }
+
+    @Test
+    public void testPlannedVmWithoutHostFallsBackToDatabase() {
+        VMInstanceVO plannedVm = org.mockito.Mockito.mock(VMInstanceVO.class);
+        when(plannedVm.getId()).thenReturn(GROUP_VM_ID);
+        when(plannedVm.getHostId()).thenReturn(null);
+
+        when(_vmInstanceDao.findById(GROUP_VM_ID)).thenReturn(groupVM);
+        when(groupVM.isRemoved()).thenReturn(false);
+        when(groupVM.getHostId()).thenReturn(HOST_ID);
+
+        processor.processAffinityGroup(vmGroupMapping, avoid, vm, Arrays.asList(plannedVm));
+
+        assertTrue(avoids(HOST_ID));
+    }
+
+    @Test
+    public void testEmptyVmListBehavesAsBefore() {
+        when(_vmInstanceDao.findById(GROUP_VM_ID)).thenReturn(groupVM);
+        when(groupVM.isRemoved()).thenReturn(false);
+        when(groupVM.getHostId()).thenReturn(HOST_ID);
+
+        processor.processAffinityGroup(vmGroupMapping, avoid, vm, Collections.emptyList());
+
+        assertTrue(avoids(HOST_ID));
     }
 
     @Test

--- a/plugins/affinity-group-processors/host-anti-affinity/src/test/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessorTest.java
+++ b/plugins/affinity-group-processors/host-anti-affinity/src/test/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessorTest.java
@@ -1,0 +1,167 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.affinity;
+
+import com.cloud.deploy.DeploymentPlanner.ExcludeList;
+import com.cloud.utils.DateUtil;
+import com.cloud.vm.VMInstanceVO;
+import com.cloud.vm.VirtualMachine;
+import com.cloud.vm.dao.VMInstanceDao;
+import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
+import org.apache.cloudstack.affinity.dao.AffinityGroupVMMapDao;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnit4.class)
+public class HostAntiAffinityProcessorTest {
+
+    private static final long AFFINITY_GROUP_ID = 2L;
+    private static final long VM_ID = 3L;
+    private static final long GROUP_VM_ID = 1L;
+    private static final long HOST_ID = 10L;
+    private static final long LAST_HOST_ID = 11L;
+    private static final int CAPACITY_RELEASE_INTERVAL = 3600;
+
+    @Mock
+    AffinityGroupDao _affinityGroupDao;
+
+    @Mock
+    AffinityGroupVMMapDao _affinityGroupVMMapDao;
+
+    @Mock
+    VMInstanceDao _vmInstanceDao;
+
+    @Spy
+    @InjectMocks
+    HostAntiAffinityProcessor processor = new HostAntiAffinityProcessor();
+
+    @Mock
+    VirtualMachine vm;
+
+    @Mock
+    VMInstanceVO groupVM;
+
+    @Mock
+    AffinityGroupVO affinityGroupVO;
+
+    @Mock
+    AffinityGroupVMMapVO vmGroupMapping;
+
+    private ExcludeList avoid;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        processor._vmCapacityReleaseInterval = CAPACITY_RELEASE_INTERVAL;
+        avoid = new ExcludeList();
+
+        when(vm.getId()).thenReturn(VM_ID);
+        when(vmGroupMapping.getAffinityGroupId()).thenReturn(AFFINITY_GROUP_ID);
+        when(_affinityGroupDao.findById(AFFINITY_GROUP_ID)).thenReturn(affinityGroupVO);
+        when(affinityGroupVO.getId()).thenReturn(AFFINITY_GROUP_ID);
+        when(_affinityGroupVMMapDao.listVmIdsByAffinityGroup(AFFINITY_GROUP_ID))
+                .thenReturn(new ArrayList<>(Arrays.asList(GROUP_VM_ID, VM_ID)));
+    }
+
+    private boolean avoids(long hostId) {
+        return avoid.getHostsToAvoid() != null && avoid.getHostsToAvoid().contains(hostId);
+    }
+
+    @Test
+    public void testRunningGroupVmHostIsAvoided() {
+        when(_vmInstanceDao.findById(GROUP_VM_ID)).thenReturn(groupVM);
+        when(groupVM.isRemoved()).thenReturn(false);
+        when(groupVM.getHostId()).thenReturn(HOST_ID);
+
+        processor.processAffinityGroup(vmGroupMapping, avoid, vm);
+
+        assertTrue(avoids(HOST_ID));
+    }
+
+    @Test
+    public void testStoppedGroupVmWithReservedCapacityLastHostIsAvoided() {
+        when(_vmInstanceDao.findById(GROUP_VM_ID)).thenReturn(groupVM);
+        when(groupVM.isRemoved()).thenReturn(false);
+        when(groupVM.getHostId()).thenReturn(null);
+        when(groupVM.getState()).thenReturn(VirtualMachine.State.Stopped);
+        when(groupVM.getLastHostId()).thenReturn(LAST_HOST_ID);
+        when(groupVM.getUpdateTime()).thenReturn(DateUtil.currentGMTTime());
+
+        processor.processAffinityGroup(vmGroupMapping, avoid, vm);
+
+        assertTrue(avoids(LAST_HOST_ID));
+    }
+
+    @Test
+    public void testStoppedGroupVmPastReleaseIntervalIsNotAvoided() {
+        Date wellPast = new Date(DateUtil.currentGMTTime().getTime() - (CAPACITY_RELEASE_INTERVAL + 60) * 1000L);
+        when(_vmInstanceDao.findById(GROUP_VM_ID)).thenReturn(groupVM);
+        when(groupVM.isRemoved()).thenReturn(false);
+        when(groupVM.getHostId()).thenReturn(null);
+        when(groupVM.getState()).thenReturn(VirtualMachine.State.Stopped);
+        when(groupVM.getLastHostId()).thenReturn(LAST_HOST_ID);
+        when(groupVM.getUpdateTime()).thenReturn(wellPast);
+
+        processor.processAffinityGroup(vmGroupMapping, avoid, vm);
+
+        assertFalse(avoids(LAST_HOST_ID));
+    }
+
+    @Test
+    public void testMissingGroupVmIsSkipped() {
+        when(_vmInstanceDao.findById(GROUP_VM_ID)).thenReturn(null);
+
+        processor.processAffinityGroup(vmGroupMapping, avoid, vm);
+
+        assertTrue(avoid.getHostsToAvoid() == null || avoid.getHostsToAvoid().isEmpty());
+    }
+
+    @Test
+    public void testRemovedGroupVmIsSkipped() {
+        when(_vmInstanceDao.findById(GROUP_VM_ID)).thenReturn(groupVM);
+        when(groupVM.isRemoved()).thenReturn(true);
+
+        processor.processAffinityGroup(vmGroupMapping, avoid, vm);
+
+        assertFalse(avoids(HOST_ID));
+    }
+
+    @Test
+    public void testVmIsNotAvoidedAgainstItself() {
+        List<Long> ids = new ArrayList<>(Arrays.asList(VM_ID));
+        when(_affinityGroupVMMapDao.listVmIdsByAffinityGroup(AFFINITY_GROUP_ID)).thenReturn(ids);
+
+        processor.processAffinityGroup(vmGroupMapping, avoid, vm);
+
+        assertTrue(avoid.getHostsToAvoid() == null || avoid.getHostsToAvoid().isEmpty());
+    }
+}

--- a/plugins/affinity-group-processors/host-anti-affinity/src/test/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessorTest.java
+++ b/plugins/affinity-group-processors/host-anti-affinity/src/test/java/org/apache/cloudstack/affinity/HostAntiAffinityProcessorTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @RunWith(JUnit4.class)
@@ -151,10 +152,30 @@ public class HostAntiAffinityProcessorTest {
     public void testRemovedGroupVmIsSkipped() {
         when(_vmInstanceDao.findById(GROUP_VM_ID)).thenReturn(groupVM);
         when(groupVM.isRemoved()).thenReturn(true);
+        // a removed VM is not running anywhere, so neither of its hosts should be avoided
+        lenient().when(groupVM.getHostId()).thenReturn(HOST_ID);
+        lenient().when(groupVM.getState()).thenReturn(VirtualMachine.State.Stopped);
+        lenient().when(groupVM.getLastHostId()).thenReturn(LAST_HOST_ID);
+        lenient().when(groupVM.getUpdateTime()).thenReturn(DateUtil.currentGMTTime());
 
         processor.processAffinityGroup(vmGroupMapping, avoid, vm);
 
         assertFalse(avoids(HOST_ID));
+        assertFalse(avoids(LAST_HOST_ID));
+    }
+
+    @Test
+    public void testStartingGroupVmWithReservedCapacityLastHostIsAvoided() {
+        when(_vmInstanceDao.findById(GROUP_VM_ID)).thenReturn(groupVM);
+        when(groupVM.isRemoved()).thenReturn(false);
+        when(groupVM.getHostId()).thenReturn(null);
+        when(groupVM.getState()).thenReturn(VirtualMachine.State.Starting);
+        when(groupVM.getLastHostId()).thenReturn(LAST_HOST_ID);
+        when(groupVM.getUpdateTime()).thenReturn(DateUtil.currentGMTTime());
+
+        processor.processAffinityGroup(vmGroupMapping, avoid, vm);
+
+        assertTrue(avoids(LAST_HOST_ID));
     }
 
     @Test

--- a/plugins/affinity-group-processors/non-strict-host-affinity/src/main/java/org/apache/cloudstack/affinity/NonStrictHostAffinityProcessor.java
+++ b/plugins/affinity-group-processors/non-strict-host-affinity/src/main/java/org/apache/cloudstack/affinity/NonStrictHostAffinityProcessor.java
@@ -18,7 +18,6 @@ package org.apache.cloudstack.affinity;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -111,14 +110,6 @@ public class NonStrictHostAffinityProcessor extends AffinityProcessorBase implem
                 processVmInAffinityGroup(plan, groupVM);
             }
         }
-    }
-
-    protected Map<Long, VirtualMachine> getVmIdVmMap(List<VirtualMachine> vmList) {
-        Map<Long, VirtualMachine> vmIdVmMap = new HashMap<>();
-        for (VirtualMachine vm : vmList) {
-            vmIdVmMap.put(vm.getId(), vm);
-        }
-        return vmIdVmMap;
     }
 
     protected void processVmInAffinityGroup(DeploymentPlan plan, VMInstanceVO groupVM) {

--- a/plugins/affinity-group-processors/non-strict-host-affinity/src/main/java/org/apache/cloudstack/affinity/NonStrictHostAffinityProcessor.java
+++ b/plugins/affinity-group-processors/non-strict-host-affinity/src/main/java/org/apache/cloudstack/affinity/NonStrictHostAffinityProcessor.java
@@ -17,6 +17,8 @@
 package org.apache.cloudstack.affinity;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -67,13 +69,24 @@ public class NonStrictHostAffinityProcessor extends AffinityProcessorBase implem
 
         for (AffinityGroupVMMapVO vmGroupMapping : vmGroupMappings) {
             if (vmGroupMapping != null) {
-                processAffinityGroup(vmGroupMapping, plan, vm);
+                processAffinityGroup(vmGroupMapping, plan, vm, vmList);
             }
         }
 
     }
 
     protected void processAffinityGroup(AffinityGroupVMMapVO vmGroupMapping, DeploymentPlan plan, VirtualMachine vm) {
+        processAffinityGroup(vmGroupMapping, plan, vm, Collections.emptyList());
+    }
+
+    /**
+     * Adjusts host priorities for one group.
+     *
+     * @param vmList
+     *         placements to honour in preference to what the database says, for callers such as DRS
+     *         that build a plan in memory before persisting it.
+     */
+    protected void processAffinityGroup(AffinityGroupVMMapVO vmGroupMapping, DeploymentPlan plan, VirtualMachine vm, List<VirtualMachine> vmList) {
         AffinityGroupVO group = affinityGroupDao.findById(vmGroupMapping.getAffinityGroupId());
 
         if (logger.isDebugEnabled()) {
@@ -83,12 +96,29 @@ public class NonStrictHostAffinityProcessor extends AffinityProcessorBase implem
         List<Long> groupVMIds = affinityGroupVMMapDao.listVmIdsByAffinityGroup(group.getId());
         groupVMIds.remove(vm.getId());
 
+        Map<Long, VirtualMachine> plannedVms = getVmIdVmMap(vmList);
+
         for (Long groupVMId : groupVMIds) {
+            VirtualMachine plannedVm = plannedVms.get(groupVMId);
+            if (plannedVm != null && plannedVm.getHostId() != null) {
+                Integer priority = adjustHostPriority(plan, plannedVm.getHostId());
+                logger.debug("Updated host {} priority to {}, since VM {} is placed on the host by the plan being built",
+                        plannedVm.getHostId(), priority, plannedVm);
+                continue;
+            }
             VMInstanceVO groupVM = vmInstanceDao.findById(groupVMId);
             if (groupVM != null && !groupVM.isRemoved()) {
                 processVmInAffinityGroup(plan, groupVM);
             }
         }
+    }
+
+    protected Map<Long, VirtualMachine> getVmIdVmMap(List<VirtualMachine> vmList) {
+        Map<Long, VirtualMachine> vmIdVmMap = new HashMap<>();
+        for (VirtualMachine vm : vmList) {
+            vmIdVmMap.put(vm.getId(), vm);
+        }
+        return vmIdVmMap;
     }
 
     protected void processVmInAffinityGroup(DeploymentPlan plan, VMInstanceVO groupVM) {

--- a/plugins/affinity-group-processors/non-strict-host-affinity/src/test/java/org/apache/cloudstack/affinity/NonStrictHostAffinityProcessorTest.java
+++ b/plugins/affinity-group-processors/non-strict-host-affinity/src/test/java/org/apache/cloudstack/affinity/NonStrictHostAffinityProcessorTest.java
@@ -170,4 +170,37 @@ public class NonStrictHostAffinityProcessorTest {
         Assert.assertNotNull(plan.getHostPriorities().get(host2Id));
         Assert.assertEquals(Integer.valueOf(1), plan.getHostPriorities().get(host2Id));
     }
+
+    @Test
+    public void testPlannedHostWinsOverStaleDatabaseHost() {
+        VirtualMachine vm = Mockito.mock(VirtualMachine.class);
+        when(vm.getId()).thenReturn(vmId);
+        VirtualMachineProfile vmProfile = Mockito.mock(VirtualMachineProfile.class);
+        when(vmProfile.getVirtualMachine()).thenReturn(vm);
+
+        List<AffinityGroupVMMapVO> vmGroupMappings = new ArrayList<>();
+        vmGroupMappings.add(new AffinityGroupVMMapVO(affinityGroupId, vmId));
+        when(_affinityGroupVMMapDao.findByVmIdType(eq(vmId), nullable(String.class))).thenReturn(vmGroupMappings);
+
+        DataCenterDeployment plan = new DataCenterDeployment(zoneId);
+        ExcludeList avoid = new ExcludeList();
+
+        AffinityGroupVO affinityGroupVO = Mockito.mock(AffinityGroupVO.class);
+        when(affinityGroupDao.findById(affinityGroupId)).thenReturn(affinityGroupVO);
+        when(affinityGroupVO.getId()).thenReturn(affinityGroupId);
+        when(_affinityGroupVMMapDao.listVmIdsByAffinityGroup(affinityGroupId))
+                .thenReturn(new ArrayList<>(Arrays.asList(vmId, vm2Id)));
+
+        // the plan being built has already moved vm2 to host3; the database is not consulted
+        VMInstanceVO planned = Mockito.mock(VMInstanceVO.class);
+        when(planned.getId()).thenReturn(vm2Id);
+        when(planned.getHostId()).thenReturn(host3Id);
+
+        processor.process(vmProfile, plan, avoid, Arrays.asList(planned));
+
+        Assert.assertEquals(1, plan.getHostPriorities().size());
+        Assert.assertNotNull(plan.getHostPriorities().get(host3Id));
+        Assert.assertNull(plan.getHostPriorities().get(host2Id));
+        Mockito.verify(vmInstanceDao, Mockito.never()).findById(vm2Id);
+    }
 }

--- a/server/src/main/java/org/apache/cloudstack/cluster/ClusterDrsServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/cluster/ClusterDrsServiceImpl.java
@@ -788,13 +788,6 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
     }
 
     /**
-     * Executes the DRS plan by migrating virtual machines to their destination hosts.
-     * If there are no migrations to be executed, the plan is marked as completed.
-     *
-     * @param plan
-     *         the DRS plan to be executed
-     */
-    /**
      * Checks a planned migration against the placement rules as they stand now.
      *
      * A plan is generated once and executed later, so state can have moved on: VMs may have been
@@ -802,8 +795,9 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
      * against current placements, and nothing downstream re-checks it - migrateVirtualMachine does
      * not enforce affinity groups.
      *
-     * The processors also cover dedicated resources and DPDK, so a refusal is not necessarily about
-     * an affinity group.
+     * Checked for every VM, not only those in an affinity group: applyAffinityConstraints also
+     * applies DPDK and dedicated-resource exclusions, which apply regardless of group membership.
+     * A refusal here is therefore not necessarily about an affinity group.
      *
      * @param vm
      *         the VM the plan wants to move
@@ -821,9 +815,6 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
             logger.debug("VM {} is no longer running, so its planned migration is out of date", vm);
             return true;
         }
-        if (CollectionUtils.isEmpty(affinityGroupVMMapDao.listByInstanceId(vm.getId()))) {
-            return false;
-        }
         if (dispatchedSourceHosts.contains(destHost.getId())) {
             logger.debug("Host {} is still occupied by a VM whose migration away from it is only queued", destHost);
             return true;
@@ -837,6 +828,13 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
         return excludes.shouldAvoid(destHost);
     }
 
+    /**
+     * Executes the DRS plan by migrating virtual machines to their destination hosts.
+     * If there are no migrations to be executed, the plan is marked as completed.
+     *
+     * @param plan
+     *         the DRS plan to be executed
+     */
     void executeDrsPlan(ClusterDrsPlanVO plan) {
         List<ClusterDrsPlanMigrationVO> planMigrations = drsPlanMigrationDao.listPlanMigrationsToExecute(plan.getId());
         if (planMigrations == null || planMigrations.isEmpty()) {

--- a/server/src/main/java/org/apache/cloudstack/cluster/ClusterDrsServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/cluster/ClusterDrsServiceImpl.java
@@ -25,6 +25,7 @@ import com.cloud.api.query.vo.HostJoinVO;
 import com.cloud.dc.ClusterVO;
 import com.cloud.dc.dao.ClusterDao;
 import com.cloud.deploy.DataCenterDeployment;
+import com.cloud.deploy.DeploymentPlan;
 import com.cloud.deploy.DeploymentPlanner.ExcludeList;
 import com.cloud.domain.Domain;
 import com.cloud.event.ActionEventUtils;
@@ -80,6 +81,7 @@ import org.apache.cloudstack.framework.jobs.impl.AsyncJobVO;
 import org.apache.cloudstack.jobs.JobInfo;
 import org.apache.cloudstack.managed.context.ManagedContextTimerTask;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.time.DateUtils;
 
 import javax.inject.Inject;
@@ -432,6 +434,29 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
         return migrationPlan;
     }
 
+    /**
+     * Turns the non-strict affinity preferences recorded on the plan into exclusions.
+     *
+     * Non-strict groups express themselves by lowering a host's priority rather than by excluding
+     * it, and DRS only reads the exclude list - so the preference was being discarded. Rebalancing
+     * is never a reason to break it: the VM is already running somewhere that satisfies the group,
+     * and leaving it there is always available to DRS. "Non-strict" means the rule may be broken
+     * when there is nowhere else to put a VM, which cannot arise while merely rebalancing.
+     */
+    protected void excludeHostsDispreferredByAffinity(DeploymentPlan plan, ExcludeList excludes) {
+        Map<Long, Integer> priorities = plan.getHostPriorities();
+        if (MapUtils.isEmpty(priorities)) {
+            return;
+        }
+        for (Map.Entry<Long, Integer> entry : priorities.entrySet()) {
+            if (entry.getValue() != null && entry.getValue() < DeploymentPlan.DEFAULT_HOST_PRIORITY) {
+                excludes.addHost(entry.getKey());
+                logger.debug("Host {} is dispreferred by a non-strict affinity group, so DRS will not migrate onto it",
+                        entry.getKey());
+            }
+        }
+    }
+
     private Map<Long, ExcludeList> getVmToExcludesMap(List<VirtualMachine> vmList, Map<Long, Host> hostMap,
             Set<Long> vmsWithAffinityGroups, Map<Long, List<? extends Host>> vmToCompatibleHostsCache,
             Map<Long, ServiceOffering> vmIdServiceOfferingMap) {
@@ -452,6 +477,7 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
 
                         excludes = managementServer.applyAffinityConstraints(
                                 vm, vmProfile, plan, vmList);
+                        excludeHostsDispreferredByAffinity(plan, excludes);
                     } else {
                         // VM has no affinity groups - create minimal ExcludeList (just source host)
                         excludes = new ExcludeList();
@@ -776,18 +802,35 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
      * against current placements, and nothing downstream re-checks it - migrateVirtualMachine does
      * not enforce affinity groups.
      *
+     * @param vm
+     *         the VM the plan wants to move
+     * @param destHost
+     *         where the plan wants to move it
      * @param dispatched
      *         migrations already queued by this run, which the database does not reflect yet
+     * @param dispatchedSourceHosts
+     *         hosts those queued migrations have not actually left yet
+     * @return true when the migration should not go ahead
      */
-    protected boolean destinationViolatesAffinity(VirtualMachine vm, Host destHost, List<VirtualMachine> dispatched) {
+    protected boolean destinationViolatesAffinity(VirtualMachine vm, Host destHost, List<VirtualMachine> dispatched,
+            List<Long> dispatchedSourceHosts) {
+        if (vm.getHostId() == null) {
+            logger.debug("VM {} is no longer running, so its planned migration is out of date", vm);
+            return true;
+        }
         if (CollectionUtils.isEmpty(affinityGroupVMMapDao.listByInstanceId(vm.getId()))) {
             return false;
+        }
+        if (dispatchedSourceHosts.contains(destHost.getId())) {
+            logger.debug("Host {} is still occupied by a VM whose migration away from it is only queued", destHost);
+            return true;
         }
         DataCenterDeployment plan = new DataCenterDeployment(destHost.getDataCenterId(), destHost.getPodId(),
                 destHost.getClusterId(), null, null, null);
         VirtualMachineProfile vmProfile = new VirtualMachineProfileImpl(vm, null,
                 serviceOfferingDao.findByIdIncludingRemoved(vm.getId(), vm.getServiceOfferingId()), null, null);
         ExcludeList excludes = managementServer.applyAffinityConstraints(vm, vmProfile, plan, dispatched);
+        excludeHostsDispreferredByAffinity(plan, excludes);
         return excludes.shouldAvoid(destHost);
     }
 
@@ -806,7 +849,9 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
         plan.setStatus(ClusterDrsPlan.Status.IN_PROGRESS);
         drsPlanDao.update(plan.getId(), plan);
 
+        // a queued migration occupies both ends until it completes, and it may not complete at all
         List<VirtualMachine> dispatched = new ArrayList<>();
+        List<Long> dispatchedSourceHosts = new ArrayList<>();
 
         for (ClusterDrsPlanMigrationVO migration : planMigrations) {
             try {
@@ -817,7 +862,7 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
                             migration.getDestHostId()));
                 }
 
-                if (destinationViolatesAffinity(vm, host, dispatched)) {
+                if (destinationViolatesAffinity(vm, host, dispatched, dispatchedSourceHosts)) {
                     logger.warn("Skipping DRS migration of vm {} to host {}: it no longer satisfies the affinity " +
                             "rules for that VM. The plan was generated against older state.", vm, host);
                     migration.setStatus(JobInfo.Status.FAILED);
@@ -833,11 +878,16 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
                 drsPlanMigrationDao.update(migration.getId(), migration);
 
                 // the migration job has only been queued, so the database still shows the old host.
-                // record where it is headed so later migrations in this plan see it.
+                // record both ends: the VM is headed for the destination but has not left the
+                // source, and if the job fails it never will.
+                Long sourceHostId = vm.getHostId();
+                if (sourceHostId != null) {
+                    dispatchedSourceHosts.add(sourceHostId);
+                }
                 vm.setHostId(host.getId());
                 dispatched.add(vm);
             } catch (Exception e) {
-                logger.warn("Unable to execute DRS plan {} due to {}", plan, e.getMessage());
+                logger.warn("Unable to execute DRS plan {}", plan, e);
                 migration.setStatus(JobInfo.Status.FAILED);
                 drsPlanMigrationDao.update(migration.getId(), migration);
             }

--- a/server/src/main/java/org/apache/cloudstack/cluster/ClusterDrsServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/cluster/ClusterDrsServiceImpl.java
@@ -768,6 +768,29 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
      * @param plan
      *         the DRS plan to be executed
      */
+    /**
+     * Checks a planned migration against the affinity rules as they stand now.
+     *
+     * A plan is generated once and executed later, so state can have moved on: VMs may have been
+     * created, migrated or destroyed in between. Anti-affinity in particular is only meaningful
+     * against current placements, and nothing downstream re-checks it - migrateVirtualMachine does
+     * not enforce affinity groups.
+     *
+     * @param dispatched
+     *         migrations already queued by this run, which the database does not reflect yet
+     */
+    protected boolean destinationViolatesAffinity(VirtualMachine vm, Host destHost, List<VirtualMachine> dispatched) {
+        if (CollectionUtils.isEmpty(affinityGroupVMMapDao.listByInstanceId(vm.getId()))) {
+            return false;
+        }
+        DataCenterDeployment plan = new DataCenterDeployment(destHost.getDataCenterId(), destHost.getPodId(),
+                destHost.getClusterId(), null, null, null);
+        VirtualMachineProfile vmProfile = new VirtualMachineProfileImpl(vm, null,
+                serviceOfferingDao.findByIdIncludingRemoved(vm.getId(), vm.getServiceOfferingId()), null, null);
+        ExcludeList excludes = managementServer.applyAffinityConstraints(vm, vmProfile, plan, dispatched);
+        return excludes.shouldAvoid(destHost);
+    }
+
     void executeDrsPlan(ClusterDrsPlanVO plan) {
         List<ClusterDrsPlanMigrationVO> planMigrations = drsPlanMigrationDao.listPlanMigrationsToExecute(plan.getId());
         if (planMigrations == null || planMigrations.isEmpty()) {
@@ -783,13 +806,23 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
         plan.setStatus(ClusterDrsPlan.Status.IN_PROGRESS);
         drsPlanDao.update(plan.getId(), plan);
 
+        List<VirtualMachine> dispatched = new ArrayList<>();
+
         for (ClusterDrsPlanMigrationVO migration : planMigrations) {
             try {
-                VirtualMachine vm = vmInstanceDao.findById(migration.getVmId());
+                VMInstanceVO vm = vmInstanceDao.findById(migration.getVmId());
                 Host host = hostDao.findById(migration.getDestHostId());
                 if (vm == null || host == null) {
                     throw new CloudRuntimeException(String.format("vm %s or host %s is not found", migration.getVmId(),
                             migration.getDestHostId()));
+                }
+
+                if (destinationViolatesAffinity(vm, host, dispatched)) {
+                    logger.warn("Skipping DRS migration of vm {} to host {}: it no longer satisfies the affinity " +
+                            "rules for that VM. The plan was generated against older state.", vm, host);
+                    migration.setStatus(JobInfo.Status.FAILED);
+                    drsPlanMigrationDao.update(migration.getId(), migration);
+                    continue;
                 }
 
                 logger.debug("Executing DRS plan {} for vm {} to host {}", plan, vm, host);
@@ -798,6 +831,11 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
                 migration.setJobId(jobId);
                 migration.setStatus(job.getStatus());
                 drsPlanMigrationDao.update(migration.getId(), migration);
+
+                // the migration job has only been queued, so the database still shows the old host.
+                // record where it is headed so later migrations in this plan see it.
+                vm.setHostId(host.getId());
+                dispatched.add(vm);
             } catch (Exception e) {
                 logger.warn("Unable to execute DRS plan {} due to {}", plan, e.getMessage());
                 migration.setStatus(JobInfo.Status.FAILED);

--- a/server/src/main/java/org/apache/cloudstack/cluster/ClusterDrsServiceImpl.java
+++ b/server/src/main/java/org/apache/cloudstack/cluster/ClusterDrsServiceImpl.java
@@ -795,12 +795,15 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
      *         the DRS plan to be executed
      */
     /**
-     * Checks a planned migration against the affinity rules as they stand now.
+     * Checks a planned migration against the placement rules as they stand now.
      *
      * A plan is generated once and executed later, so state can have moved on: VMs may have been
      * created, migrated or destroyed in between. Anti-affinity in particular is only meaningful
      * against current placements, and nothing downstream re-checks it - migrateVirtualMachine does
      * not enforce affinity groups.
+     *
+     * The processors also cover dedicated resources and DPDK, so a refusal is not necessarily about
+     * an affinity group.
      *
      * @param vm
      *         the VM the plan wants to move
@@ -863,10 +866,16 @@ public class ClusterDrsServiceImpl extends ManagerBase implements ClusterDrsServ
                 }
 
                 if (destinationViolatesAffinity(vm, host, dispatched, dispatchedSourceHosts)) {
-                    logger.warn("Skipping DRS migration of vm {} to host {}: it no longer satisfies the affinity " +
-                            "rules for that VM. The plan was generated against older state.", vm, host);
-                    migration.setStatus(JobInfo.Status.FAILED);
+                    String reason = String.format("Skipped DRS migration of %s to %s: the destination no longer "
+                            + "satisfies the placement rules for that VM. The plan was generated against older "
+                            + "state.", vm, host);
+                    logger.warn(reason);
+                    // cancelled rather than failed: nothing went wrong, the plan went out of date
+                    migration.setStatus(JobInfo.Status.CANCELLED);
                     drsPlanMigrationDao.update(migration.getId(), migration);
+                    ActionEventUtils.onCompletedActionEvent(User.UID_SYSTEM, Account.ACCOUNT_ID_SYSTEM,
+                            EventVO.LEVEL_WARN, EventTypes.EVENT_CLUSTER_DRS, false, reason,
+                            plan.getClusterId(), ApiCommandResourceType.Cluster.toString(), plan.getEventId());
                     continue;
                 }
 

--- a/server/src/test/java/org/apache/cloudstack/cluster/ClusterDrsServiceImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/cluster/ClusterDrsServiceImplTest.java
@@ -993,15 +993,20 @@ public class ClusterDrsServiceImplTest {
     }
 
     @Test
-    public void testDestinationAllowedWhenVmHasNoAffinityGroups() {
+    public void testAVmWithNoAffinityGroupsIsStillRechecked() {
+        // applyAffinityConstraints also applies DPDK and dedicated-resource exclusions, which do
+        // not depend on affinity group membership, so every VM has to go through it
         VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
         Mockito.when(vm.getId()).thenReturn(1L);
         Mockito.when(vm.getHostId()).thenReturn(10L);
-        Mockito.when(affinityGroupVMMapDao.listByInstanceId(1L)).thenReturn(Collections.emptyList());
+        Mockito.when(vm.getServiceOfferingId()).thenReturn(5L);
+        Mockito.when(serviceOfferingDao.findByIdIncludingRemoved(1L, 5L))
+                .thenReturn(Mockito.mock(ServiceOfferingVO.class));
+        affinityExcludes(21L);
 
         assertFalse(clusterDrsService.destinationViolatesAffinity(vm, host(20L),
                 Collections.emptyList(), Collections.emptyList()));
-        Mockito.verify(managementServer, Mockito.never())
+        Mockito.verify(managementServer)
                 .applyAffinityConstraints(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
     }
 

--- a/server/src/test/java/org/apache/cloudstack/cluster/ClusterDrsServiceImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/cluster/ClusterDrsServiceImplTest.java
@@ -1110,7 +1110,7 @@ public class ClusterDrsServiceImplTest {
 
         clusterDrsService.executeDrsPlan(plan);
 
-        Mockito.verify(migration).setStatus(JobInfo.Status.FAILED);
+        Mockito.verify(migration).setStatus(JobInfo.Status.CANCELLED);
         Mockito.verify(clusterDrsService, Mockito.never())
                 .createMigrateVMAsyncJob(Mockito.any(), Mockito.any(), Mockito.anyLong());
     }

--- a/server/src/test/java/org/apache/cloudstack/cluster/ClusterDrsServiceImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/cluster/ClusterDrsServiceImplTest.java
@@ -30,6 +30,8 @@ import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
 import com.cloud.deploy.DeploymentPlanner.ExcludeList;
+import com.cloud.deploy.DeploymentPlan;
+import com.cloud.deploy.DataCenterDeployment;
 import com.cloud.host.dao.HostDao;
 import com.cloud.offering.ServiceOffering;
 import com.cloud.org.Cluster;
@@ -63,6 +65,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -72,7 +75,10 @@ import javax.naming.ConfigurationException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Arrays;
 import org.apache.cloudstack.jobs.JobInfo;
+import org.apache.cloudstack.framework.jobs.AsyncJobManager;
+import org.apache.cloudstack.framework.jobs.impl.AsyncJobVO;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -126,6 +132,9 @@ public class ClusterDrsServiceImplTest {
 
     @Mock
     private AffinityGroupVMMapDao affinityGroupVMMapDao;
+
+    @Mock
+    private AsyncJobManager asyncJobManager;
 
     @Mock
     private VMInstanceDetailsDao vmInstanceDetailsDao;
@@ -956,59 +965,127 @@ public class ClusterDrsServiceImplTest {
         Mockito.verify(clusterDrsService, Mockito.times(2)).executeDrsPlan(Mockito.any(ClusterDrsPlanVO.class));
     }
 
+    private VMInstanceVO vmWithAffinityGroup(long id, Long hostId) {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.lenient().when(vm.getId()).thenReturn(id);
+        Mockito.lenient().when(vm.getHostId()).thenReturn(hostId);
+        Mockito.lenient().when(vm.getServiceOfferingId()).thenReturn(5L);
+        Mockito.lenient().when(affinityGroupVMMapDao.listByInstanceId(id))
+                .thenReturn(Collections.singletonList(Mockito.mock(AffinityGroupVMMapVO.class)));
+        Mockito.lenient().when(serviceOfferingDao.findByIdIncludingRemoved(id, 5L))
+                .thenReturn(Mockito.mock(ServiceOfferingVO.class));
+        return vm;
+    }
+
+    private HostVO host(long id) {
+        HostVO host = Mockito.mock(HostVO.class);
+        Mockito.lenient().when(host.getId()).thenReturn(id);
+        return host;
+    }
+
+    private void affinityExcludes(Long... hostIds) {
+        ExcludeList excludes = new ExcludeList();
+        for (Long hostId : hostIds) {
+            excludes.addHost(hostId);
+        }
+        Mockito.when(managementServer.applyAffinityConstraints(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(excludes);
+    }
+
     @Test
-    public void testDestinationViolatesAffinityWhenVmHasNoAffinityGroups() {
+    public void testDestinationAllowedWhenVmHasNoAffinityGroups() {
         VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
         Mockito.when(vm.getId()).thenReturn(1L);
+        Mockito.when(vm.getHostId()).thenReturn(10L);
         Mockito.when(affinityGroupVMMapDao.listByInstanceId(1L)).thenReturn(Collections.emptyList());
 
-        HostVO destHost = Mockito.mock(HostVO.class);
-
-        assertFalse(clusterDrsService.destinationViolatesAffinity(vm, destHost, Collections.emptyList()));
+        assertFalse(clusterDrsService.destinationViolatesAffinity(vm, host(20L),
+                Collections.emptyList(), Collections.emptyList()));
         Mockito.verify(managementServer, Mockito.never())
                 .applyAffinityConstraints(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
     }
 
     @Test
-    public void testDestinationViolatesAffinityWhenDestHostIsExcluded() {
-        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
-        Mockito.when(vm.getId()).thenReturn(1L);
-        Mockito.when(vm.getServiceOfferingId()).thenReturn(5L);
-        Mockito.when(affinityGroupVMMapDao.listByInstanceId(1L))
-                .thenReturn(Collections.singletonList(Mockito.mock(AffinityGroupVMMapVO.class)));
-        Mockito.when(serviceOfferingDao.findByIdIncludingRemoved(1L, 5L))
-                .thenReturn(Mockito.mock(ServiceOfferingVO.class));
+    public void testDestinationRefusedWhenAffinityExcludesIt() {
+        VMInstanceVO vm = vmWithAffinityGroup(1L, 10L);
+        affinityExcludes(20L);
 
-        HostVO destHost = Mockito.mock(HostVO.class);
-        Mockito.when(destHost.getId()).thenReturn(20L);
-
-        ExcludeList excludes = new ExcludeList();
-        excludes.addHost(20L);
-        Mockito.when(managementServer.applyAffinityConstraints(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(excludes);
-
-        assertTrue(clusterDrsService.destinationViolatesAffinity(vm, destHost, Collections.emptyList()));
+        assertTrue(clusterDrsService.destinationViolatesAffinity(vm, host(20L),
+                Collections.emptyList(), Collections.emptyList()));
     }
 
     @Test
-    public void testDestinationViolatesAffinityWhenDestHostIsAllowed() {
+    public void testDestinationAllowedWhenAffinityExcludesSomewhereElse() {
+        VMInstanceVO vm = vmWithAffinityGroup(1L, 10L);
+        affinityExcludes(21L);
+
+        assertFalse(clusterDrsService.destinationViolatesAffinity(vm, host(20L),
+                Collections.emptyList(), Collections.emptyList()));
+    }
+
+    @Test
+    public void testDestinationRefusedWhenVmIsNoLongerRunning() {
         VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
-        Mockito.when(vm.getId()).thenReturn(1L);
-        Mockito.when(vm.getServiceOfferingId()).thenReturn(5L);
-        Mockito.when(affinityGroupVMMapDao.listByInstanceId(1L))
-                .thenReturn(Collections.singletonList(Mockito.mock(AffinityGroupVMMapVO.class)));
-        Mockito.when(serviceOfferingDao.findByIdIncludingRemoved(1L, 5L))
-                .thenReturn(Mockito.mock(ServiceOfferingVO.class));
+        Mockito.when(vm.getHostId()).thenReturn(null);
 
-        HostVO destHost = Mockito.mock(HostVO.class);
-        Mockito.when(destHost.getId()).thenReturn(20L);
+        assertTrue("a plan for a VM that has since stopped is out of date",
+                clusterDrsService.destinationViolatesAffinity(vm, host(20L),
+                        Collections.emptyList(), Collections.emptyList()));
+    }
 
-        ExcludeList excludes = new ExcludeList();
-        excludes.addHost(21L);
-        Mockito.when(managementServer.applyAffinityConstraints(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(excludes);
+    @Test
+    public void testDestinationRefusedWhileItIsStillOccupiedByAQueuedMigration() {
+        // the swap case: A is queued to leave host1, so host1 is not free for B yet - and if A's
+        // migration fails, A never leaves at all
+        VMInstanceVO b = vmWithAffinityGroup(2L, 11L);
 
-        assertFalse(clusterDrsService.destinationViolatesAffinity(vm, destHost, Collections.emptyList()));
+        assertTrue("a host is not free until the VM leaving it has actually gone",
+                clusterDrsService.destinationViolatesAffinity(b, host(10L),
+                        Collections.emptyList(), Collections.singletonList(10L)));
+        Mockito.verify(managementServer, Mockito.never())
+                .applyAffinityConstraints(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void testExecuteDrsPlanKeepsSourceHostsOccupiedAcrossMigrations() {
+        // plan: A host10 -> host12, B host11 -> host10. B must not be sent to host10.
+        ClusterDrsPlanVO plan = Mockito.mock(ClusterDrsPlanVO.class);
+        Mockito.when(plan.getId()).thenReturn(1L);
+
+        ClusterDrsPlanMigrationVO first = Mockito.mock(ClusterDrsPlanMigrationVO.class);
+        Mockito.when(first.getVmId()).thenReturn(1L);
+        Mockito.when(first.getDestHostId()).thenReturn(12L);
+        ClusterDrsPlanMigrationVO second = Mockito.mock(ClusterDrsPlanMigrationVO.class);
+        Mockito.when(second.getId()).thenReturn(8L);
+        Mockito.when(second.getVmId()).thenReturn(2L);
+        Mockito.when(second.getDestHostId()).thenReturn(10L);
+        Mockito.when(drsPlanMigrationDao.listPlanMigrationsToExecute(1L))
+                .thenReturn(Arrays.asList(first, second));
+
+        VMInstanceVO a = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(a.getHostId()).thenReturn(10L);
+        VMInstanceVO b = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vmInstanceDao.findById(1L)).thenReturn(a);
+        Mockito.when(vmInstanceDao.findById(2L)).thenReturn(b);
+        HostVO host12 = host(12L);
+        HostVO host10 = host(10L);
+        Mockito.when(hostDao.findById(12L)).thenReturn(host12);
+        Mockito.when(hostDao.findById(10L)).thenReturn(host10);
+
+        Mockito.doReturn(false).when(clusterDrsService).destinationViolatesAffinity(
+                Mockito.eq(a), Mockito.any(), Mockito.any(), Mockito.any());
+        Mockito.doReturn(1L).when(clusterDrsService)
+                .createMigrateVMAsyncJob(Mockito.any(), Mockito.any(), Mockito.anyLong());
+        Mockito.when(asyncJobManager.getAsyncJob(1L)).thenReturn(Mockito.mock(AsyncJobVO.class));
+
+        clusterDrsService.executeDrsPlan(plan);
+
+        // A's source host must have been carried into the check for B
+        ArgumentCaptor<List> sources = ArgumentCaptor.forClass(List.class);
+        Mockito.verify(clusterDrsService).destinationViolatesAffinity(
+                Mockito.eq(b), Mockito.any(), Mockito.any(), sources.capture());
+        assertTrue("the host A is leaving must still count as occupied",
+                sources.getValue().contains(10L));
     }
 
     @Test
@@ -1024,17 +1101,34 @@ public class ClusterDrsServiceImplTest {
                 .thenReturn(Collections.singletonList(migration));
 
         VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
-        HostVO destHost = Mockito.mock(HostVO.class);
+        HostVO host20 = host(20L);
         Mockito.when(vmInstanceDao.findById(1L)).thenReturn(vm);
-        Mockito.when(hostDao.findById(20L)).thenReturn(destHost);
+        Mockito.when(hostDao.findById(20L)).thenReturn(host20);
 
         Mockito.doReturn(true).when(clusterDrsService)
-                .destinationViolatesAffinity(Mockito.any(), Mockito.any(), Mockito.any());
+                .destinationViolatesAffinity(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
 
         clusterDrsService.executeDrsPlan(plan);
 
         Mockito.verify(migration).setStatus(JobInfo.Status.FAILED);
         Mockito.verify(clusterDrsService, Mockito.never())
                 .createMigrateVMAsyncJob(Mockito.any(), Mockito.any(), Mockito.anyLong());
+    }
+
+    @Test
+    public void testNonStrictAntiAffinityIsHonoured() {
+        // a non-strict group lowers a host's priority rather than excluding it. rebalancing is
+        // never a reason to break it, since not migrating is always available.
+        DataCenterDeployment plan = new DataCenterDeployment(1L, 1L, 1L, null, null, null);
+        plan.adjustHostPriority(30L, DeploymentPlan.HostPriorityAdjustment.LOWER);
+        plan.adjustHostPriority(31L, DeploymentPlan.HostPriorityAdjustment.HIGHER);
+
+        ExcludeList excludes = new ExcludeList();
+        clusterDrsService.excludeHostsDispreferredByAffinity(plan, excludes);
+
+        assertTrue("a dispreferred host must not be a DRS destination",
+                excludes.getHostsToAvoid().contains(30L));
+        assertFalse("a preferred host must stay available",
+                excludes.getHostsToAvoid().contains(31L));
     }
 }

--- a/server/src/test/java/org/apache/cloudstack/cluster/ClusterDrsServiceImplTest.java
+++ b/server/src/test/java/org/apache/cloudstack/cluster/ClusterDrsServiceImplTest.java
@@ -29,12 +29,14 @@ import com.cloud.event.dao.EventDao;
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.host.Host;
 import com.cloud.host.HostVO;
+import com.cloud.deploy.DeploymentPlanner.ExcludeList;
 import com.cloud.host.dao.HostDao;
 import com.cloud.offering.ServiceOffering;
 import com.cloud.org.Cluster;
 import com.cloud.org.Grouping;
 import com.cloud.server.ManagementServer;
 import com.cloud.service.ServiceOfferingVO;
+import org.apache.cloudstack.affinity.AffinityGroupVMMapVO;
 import com.cloud.service.dao.ServiceOfferingDao;
 import com.cloud.utils.Pair;
 import com.cloud.utils.Ternary;
@@ -70,6 +72,7 @@ import javax.naming.ConfigurationException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
+import org.apache.cloudstack.jobs.JobInfo;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -77,6 +80,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -950,5 +954,87 @@ public class ClusterDrsServiceImplTest {
         clusterDrsService.processPlans();
 
         Mockito.verify(clusterDrsService, Mockito.times(2)).executeDrsPlan(Mockito.any(ClusterDrsPlanVO.class));
+    }
+
+    @Test
+    public void testDestinationViolatesAffinityWhenVmHasNoAffinityGroups() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getId()).thenReturn(1L);
+        Mockito.when(affinityGroupVMMapDao.listByInstanceId(1L)).thenReturn(Collections.emptyList());
+
+        HostVO destHost = Mockito.mock(HostVO.class);
+
+        assertFalse(clusterDrsService.destinationViolatesAffinity(vm, destHost, Collections.emptyList()));
+        Mockito.verify(managementServer, Mockito.never())
+                .applyAffinityConstraints(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void testDestinationViolatesAffinityWhenDestHostIsExcluded() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getId()).thenReturn(1L);
+        Mockito.when(vm.getServiceOfferingId()).thenReturn(5L);
+        Mockito.when(affinityGroupVMMapDao.listByInstanceId(1L))
+                .thenReturn(Collections.singletonList(Mockito.mock(AffinityGroupVMMapVO.class)));
+        Mockito.when(serviceOfferingDao.findByIdIncludingRemoved(1L, 5L))
+                .thenReturn(Mockito.mock(ServiceOfferingVO.class));
+
+        HostVO destHost = Mockito.mock(HostVO.class);
+        Mockito.when(destHost.getId()).thenReturn(20L);
+
+        ExcludeList excludes = new ExcludeList();
+        excludes.addHost(20L);
+        Mockito.when(managementServer.applyAffinityConstraints(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(excludes);
+
+        assertTrue(clusterDrsService.destinationViolatesAffinity(vm, destHost, Collections.emptyList()));
+    }
+
+    @Test
+    public void testDestinationViolatesAffinityWhenDestHostIsAllowed() {
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        Mockito.when(vm.getId()).thenReturn(1L);
+        Mockito.when(vm.getServiceOfferingId()).thenReturn(5L);
+        Mockito.when(affinityGroupVMMapDao.listByInstanceId(1L))
+                .thenReturn(Collections.singletonList(Mockito.mock(AffinityGroupVMMapVO.class)));
+        Mockito.when(serviceOfferingDao.findByIdIncludingRemoved(1L, 5L))
+                .thenReturn(Mockito.mock(ServiceOfferingVO.class));
+
+        HostVO destHost = Mockito.mock(HostVO.class);
+        Mockito.when(destHost.getId()).thenReturn(20L);
+
+        ExcludeList excludes = new ExcludeList();
+        excludes.addHost(21L);
+        Mockito.when(managementServer.applyAffinityConstraints(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(excludes);
+
+        assertFalse(clusterDrsService.destinationViolatesAffinity(vm, destHost, Collections.emptyList()));
+    }
+
+    @Test
+    public void testExecuteDrsPlanSkipsMigrationThatViolatesAffinity() {
+        ClusterDrsPlanVO plan = Mockito.mock(ClusterDrsPlanVO.class);
+        Mockito.when(plan.getId()).thenReturn(1L);
+
+        ClusterDrsPlanMigrationVO migration = Mockito.mock(ClusterDrsPlanMigrationVO.class);
+        Mockito.when(migration.getId()).thenReturn(7L);
+        Mockito.when(migration.getVmId()).thenReturn(1L);
+        Mockito.when(migration.getDestHostId()).thenReturn(20L);
+        Mockito.when(drsPlanMigrationDao.listPlanMigrationsToExecute(1L))
+                .thenReturn(Collections.singletonList(migration));
+
+        VMInstanceVO vm = Mockito.mock(VMInstanceVO.class);
+        HostVO destHost = Mockito.mock(HostVO.class);
+        Mockito.when(vmInstanceDao.findById(1L)).thenReturn(vm);
+        Mockito.when(hostDao.findById(20L)).thenReturn(destHost);
+
+        Mockito.doReturn(true).when(clusterDrsService)
+                .destinationViolatesAffinity(Mockito.any(), Mockito.any(), Mockito.any());
+
+        clusterDrsService.executeDrsPlan(plan);
+
+        Mockito.verify(migration).setStatus(JobInfo.Status.FAILED);
+        Mockito.verify(clusterDrsService, Mockito.never())
+                .createMigrateVMAsyncJob(Mockito.any(), Mockito.any(), Mockito.anyLong());
     }
 }


### PR DESCRIPTION
### Description

This PR fixes DRS generating and executing migration plans that violate host anti-affinity.

Four defects, one per commit:

| # | Defect |
|---|---|
| 1 | The reserved-capacity branch in `HostAntiAffinityProcessor` was chained to the wrong condition, making it unreachable for live VMs and throwing `NullPointerException` for a group mapping pointing at a deleted VM |
| 2 | The processor accepted a list of planned placements and ignored it, reading every group member's host from the database |
| 3 | Same gap in `NonStrictHostAffinityProcessor`, which `NonStrictHostAntiAffinityProcessor` extends |
| 4 | Nothing re-checked a plan before executing it, and non-strict groups were discarded entirely |

**Why the planned placements matter.** DRS builds a plan of several migrations in memory and persists it only at the end. While the plan is being built, the database still shows the old host for every VM the plan has already moved, so anti-affinity was evaluated against stale placements and a plan could put two anti-affine VMs on the same host. `HostAffinityProcessor` already honours the same argument; the anti-affinity processors did not.

**Why non-strict groups are honoured when rebalancing.** Non-strict groups express themselves by lowering a host's priority on the deployment plan rather than by excluding it. `ClusterDrsServiceImpl` built a plan object, handed it to the processors, read only the exclude list, and discarded the plan - so the preference was written to an object nothing read.

Non-strict means the rule may be broken when there is nowhere else to put a VM. That cannot arise while rebalancing: the VM already runs somewhere that satisfies the group, and leaving it there is always available to DRS. Being better balanced is not a reason to break it.

**Why execution is re-checked.** A plan is generated once and executed later, and nothing downstream re-checks it - `migrateVirtualMachine` does not enforce affinity groups. By execution time the cluster may have changed. A queued migration also occupies both of its hosts until it completes, and may never complete, so a swap plan (A: host1 to host3, B: host2 to host1) could clear B for host1 while A was still on it.

A migration that is no longer valid is now skipped and recorded as `CANCELLED` rather than `FAILED`, with an event, since nothing went wrong - the plan went out of date.

Related to #12473, which was closed on the grounds that non-strict groups permit live migration. They do, but that is about migrations an operator asks for, not about DRS choosing to undo a placement that already satisfied the group. Strict groups were also affected, which that report did not isolate.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

Unit tests, run against `4.22`:

- `HostAntiAffinityProcessorTest` - new, 10 cases. Covers the running host, the reserved-capacity last host in both `Stopped` and `Starting` states, expiry of the capacity release interval, removed and missing group members, and planned placements taking precedence over the database.
- `NonStrictHostAffinityProcessorTest` - added a case asserting a planned placement wins and the database is not consulted.
- `ClusterDrsServiceImplTest` - 33 cases. Added coverage for the pre-migration re-check, a VM that stopped between planning and execution, a destination still occupied by a queued migration, and non-strict preferences becoming exclusions.

The two commit-1 cases were confirmed to fail against unpatched code (one assertion failure, one `NullPointerException`).

Full `mvn test` on `api`, `server` and the four affinity processor plugins, checkstyle and license checks enabled: 0 failures.

#### How did you try to break this feature and the system with this change?

- **Non-DRS callers.** Initial deployment and the find-hosts-for-migration API pass an empty placement list. Verified that path is unchanged by commit 2 and 3. Commit 1 does change it, and deliberately: a `Stopped` group member still holding reserved capacity now has its last host avoided, where previously the branch was unreachable. That widens the avoid set on the deployment path and restores the behaviour that predates the refactor which broke it. On a small cluster it can make a deployment fail where it previously succeeded, for the duration of `capacity.skipcounting.hours`. Calling it out explicitly since it affects more than DRS.
- **Removed VMs** are no longer avoided at all, which is the other direction of the same fix - a removed VM is not running anywhere.
- **Swap plans**, where two migrations exchange hosts, are the case the source-host tracking exists for. Covered by test.
- **Plans that go stale**: VM stopped, VM already moved, destination filled by something else.
- **NPE hunting** on null hosts, null VMs, and group mappings pointing at deleted VMs.
- The affinity processors also cover dedicated resources and DPDK, so the skip message does not claim every refusal is about an affinity group.
