### PR TITLE
network: handle missing network when releasing public IP

### DIFF
--- a/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
+++ b/server/src/main/java/com/cloud/network/IpAddressManagerImpl.java
@@ -792,11 +792,15 @@ public class IpAddressManagerImpl extends ManagerBase implements IpAddressManage
                 logger.debug("Releasing ip {}; sourceNat = {}", ip, ip.isSourceNat());
             }
 
+            Network associatedNetwork = null;
             if (ip.getAssociatedWithNetworkId() != null) {
-                Network network = _networksDao.findById(ip.getAssociatedWithNetworkId());
+                associatedNetwork = _networksDao.findById(ip.getAssociatedWithNetworkId());
+            }
+
+            if (associatedNetwork != null) {
                 try {
-                    if (!applyIpAssociations(network, rulesContinueOnErrFlag)) {
-                        logger.warn("Unable to apply ip address associations for " + network);
+                    if (!applyIpAssociations(associatedNetwork, rulesContinueOnErrFlag)) {
+                        logger.warn("Unable to apply ip address associations for " + associatedNetwork);
                         success = false;
                     }
                 } catch (ResourceUnavailableException e) {

--- a/server/src/test/java/com/cloud/network/IpAddressManagerTest.java
+++ b/server/src/test/java/com/cloud/network/IpAddressManagerTest.java
@@ -58,11 +58,18 @@ import com.cloud.network.dao.IPAddressDao;
 import com.cloud.network.dao.IPAddressVO;
 import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkVO;
+import com.cloud.network.element.NetworkElement;
 import com.cloud.network.rules.StaticNat;
 import com.cloud.network.rules.StaticNatImpl;
+import com.cloud.network.vpc.VpcOfferingServiceMapVO;
+import com.cloud.network.vpc.VpcOfferingVO;
+import com.cloud.network.vpc.VpcVO;
 import com.cloud.network.vpc.dao.VpcDao;
+import com.cloud.network.vpc.dao.VpcOfferingDao;
+import com.cloud.network.vpc.dao.VpcOfferingServiceMapDao;
 import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
+import com.cloud.offerings.dao.NetworkOfferingServiceMapDao;
 import com.cloud.user.AccountVO;
 import com.cloud.utils.net.Ip;
 
@@ -116,6 +123,15 @@ public class IpAddressManagerTest {
     @Mock
     VpcDao vpcDao;
 
+    @Mock
+    VpcOfferingDao vpcOfferingDao;
+
+    @Mock
+    VpcOfferingServiceMapDao vpcOfferingServiceMapDao;
+
+    @Mock
+    NetworkOfferingServiceMapDao networkOfferingServiceMapDao;
+
     final long dummyID = 1L;
 
     final String UUID = "uuid";
@@ -144,24 +160,85 @@ public class IpAddressManagerTest {
     @Test
     public void disassociatePublicIpAddressUnassignsReleasingIpWhenAssociatedNetworkIsMissing() throws ResourceUnavailableException {
         long networkId = 2L;
-        when(ipAddressMock.getId()).thenReturn(dummyID);
-        when(ipAddressDao.acquireInLockTable(dummyID)).thenReturn(ipAddressVoMock);
+        long vpcId = 3L;
+        long vpcOfferingId = 4L;
+        prepareIpDisassociation(networkId);
         when(ipAddressVoMock.getId()).thenReturn(dummyID);
-        doReturn(true).when(ipAddressManager).cleanupIpResources(ipAddressMock, dummyID, account);
-        doReturn(ipAddressVoMock).when(ipAddressManager).markIpAsUnavailable(dummyID);
-        when(ipAddressVoMock.getAssociatedWithNetworkId()).thenReturn(networkId);
         when(ipAddressVoMock.getState()).thenReturn(IpAddress.State.Releasing);
-        when(ipAddressVoMock.getUuid()).thenReturn(UUID);
+        when(ipAddressVoMock.getVpcId()).thenReturn(vpcId);
         when(networkDao.findById(networkId)).thenReturn(null);
-        doReturn(null).when(ipAddressManager).addPublicIpAddressToQuarantine(ipAddressVoMock, account.getDomainId());
+        doReturn(publicIpQuarantineVOMock).when(ipAddressManager).addPublicIpAddressToQuarantine(ipAddressVoMock, account.getDomainId());
+
+        VpcVO vpc = mock(VpcVO.class);
+        VpcOfferingVO offering = mock(VpcOfferingVO.class);
+        when(vpcDao.findById(vpcId)).thenReturn(vpc);
+        when(vpc.getVpcOfferingId()).thenReturn(vpcOfferingId);
+        when(vpcOfferingDao.findById(vpcOfferingId)).thenReturn(offering);
+        when(offering.getId()).thenReturn(vpcOfferingId);
+        when(vpcOfferingServiceMapDao.listProvidersForServiceForVpcOffering(vpcOfferingId, Service.NetworkACL))
+                .thenReturn(Collections.singletonList(new VpcOfferingServiceMapVO(vpcOfferingId, Service.NetworkACL, Network.Provider.VPCVirtualRouter)));
+        NetworkElement element = mock(NetworkElement.class);
+        ipAddressManager._networkModel = mock(NetworkModel.class);
+        when(ipAddressManager._networkModel.getElementImplementingProvider(Network.Provider.VPCVirtualRouter.getName())).thenReturn(element);
 
         boolean result = ipAddressManager.disassociatePublicIpAddress(ipAddressMock, dummyID, account);
 
         assertTrue(result);
         verify(ipAddressManager, never()).applyIpAssociations(any(), anyBoolean());
+        verify(ipAddressManager).addPublicIpAddressToQuarantine(ipAddressVoMock, account.getDomainId());
         verify(ipAddressDao).unassignIpAddress(dummyID);
+        verify(element).releaseIp(ipAddressVoMock);
         verify(annotationDao).removeByEntityType("PUBLIC_IP_ADDRESS", UUID);
         verify(ipAddressDao).releaseFromLockTable(dummyID);
+    }
+
+    @Test
+    public void disassociatePublicIpAddressAppliesAssociationsWhenNetworkExists() throws ResourceUnavailableException {
+        verifyDisassociationWithExistingNetwork(true);
+    }
+
+    @Test
+    public void disassociatePublicIpAddressReturnsFailureWhenAssociationsFail() throws ResourceUnavailableException {
+        verifyDisassociationWithExistingNetwork(false);
+    }
+
+    private void verifyDisassociationWithExistingNetwork(boolean associationsApplied) throws ResourceUnavailableException {
+        long networkId = 2L;
+        prepareIpDisassociation(networkId);
+        NetworkVO network = mock(NetworkVO.class);
+        when(networkDao.findById(networkId)).thenReturn(network);
+        doReturn(associationsApplied).when(ipAddressManager).applyIpAssociations(network, IpAddressManagerImpl.rulesContinueOnErrFlag);
+
+        boolean result = ipAddressManager.disassociatePublicIpAddress(ipAddressMock, dummyID, account);
+
+        Assert.assertEquals(associationsApplied, result);
+        verify(ipAddressManager).applyIpAssociations(network, IpAddressManagerImpl.rulesContinueOnErrFlag);
+        verify(ipAddressManager, never()).addPublicIpAddressToQuarantine(any(), anyLong());
+        verify(ipAddressDao, never()).unassignIpAddress(anyLong());
+        verify(ipAddressDao).releaseFromLockTable(dummyID);
+    }
+
+    @Test
+    public void disassociatePublicIpAddressDoesNotUnassignFreeIpWhenNetworkIsMissing() throws ResourceUnavailableException {
+        prepareIpDisassociation(2L);
+        when(ipAddressVoMock.getState()).thenReturn(IpAddress.State.Free);
+
+        boolean result = ipAddressManager.disassociatePublicIpAddress(ipAddressMock, dummyID, account);
+
+        assertTrue(result);
+        verify(ipAddressManager, never()).applyIpAssociations(any(), anyBoolean());
+        verify(ipAddressManager, never()).addPublicIpAddressToQuarantine(any(), anyLong());
+        verify(ipAddressDao, never()).unassignIpAddress(anyLong());
+        verify(ipAddressDao).releaseFromLockTable(dummyID);
+    }
+
+    private void prepareIpDisassociation(long networkId) {
+        when(ipAddressMock.getId()).thenReturn(dummyID);
+        when(ipAddressDao.acquireInLockTable(dummyID)).thenReturn(ipAddressVoMock);
+        doReturn(true).when(ipAddressManager).cleanupIpResources(ipAddressMock, dummyID, account);
+        doReturn(ipAddressVoMock).when(ipAddressManager).markIpAsUnavailable(dummyID);
+        when(ipAddressVoMock.getAssociatedWithNetworkId()).thenReturn(networkId);
+        when(ipAddressVoMock.getUuid()).thenReturn(UUID);
     }
 
     @Test

--- a/server/src/test/java/com/cloud/network/IpAddressManagerTest.java
+++ b/server/src/test/java/com/cloud/network/IpAddressManagerTest.java
@@ -19,10 +19,13 @@ package com.cloud.network;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,6 +39,7 @@ import com.cloud.network.dao.PublicIpQuarantineDao;
 import com.cloud.network.vo.PublicIpQuarantineVO;
 import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
+import org.apache.cloudstack.annotation.dao.AnnotationDao;
 import org.apache.cloudstack.context.CallContext;
 import org.junit.Assert;
 import org.junit.Before;
@@ -56,6 +60,7 @@ import com.cloud.network.dao.NetworkDao;
 import com.cloud.network.dao.NetworkVO;
 import com.cloud.network.rules.StaticNat;
 import com.cloud.network.rules.StaticNatImpl;
+import com.cloud.network.vpc.dao.VpcDao;
 import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.offerings.dao.NetworkOfferingDao;
 import com.cloud.user.AccountVO;
@@ -105,6 +110,12 @@ public class IpAddressManagerTest {
     @Mock
     AccountManager accountManagerMock;
 
+    @Mock
+    AnnotationDao annotationDao;
+
+    @Mock
+    VpcDao vpcDao;
+
     final long dummyID = 1L;
 
     final String UUID = "uuid";
@@ -128,6 +139,29 @@ public class IpAddressManagerTest {
         networkOfferingVO.setSharedSourceNat(false);
 
         Mockito.when(networkOfferingDao.findById(Mockito.anyLong())).thenReturn(networkOfferingVO);
+    }
+
+    @Test
+    public void disassociatePublicIpAddressUnassignsReleasingIpWhenAssociatedNetworkIsMissing() throws ResourceUnavailableException {
+        long networkId = 2L;
+        when(ipAddressMock.getId()).thenReturn(dummyID);
+        when(ipAddressDao.acquireInLockTable(dummyID)).thenReturn(ipAddressVoMock);
+        when(ipAddressVoMock.getId()).thenReturn(dummyID);
+        doReturn(true).when(ipAddressManager).cleanupIpResources(ipAddressMock, dummyID, account);
+        doReturn(ipAddressVoMock).when(ipAddressManager).markIpAsUnavailable(dummyID);
+        when(ipAddressVoMock.getAssociatedWithNetworkId()).thenReturn(networkId);
+        when(ipAddressVoMock.getState()).thenReturn(IpAddress.State.Releasing);
+        when(ipAddressVoMock.getUuid()).thenReturn(UUID);
+        when(networkDao.findById(networkId)).thenReturn(null);
+        doReturn(null).when(ipAddressManager).addPublicIpAddressToQuarantine(ipAddressVoMock, account.getDomainId());
+
+        boolean result = ipAddressManager.disassociatePublicIpAddress(ipAddressMock, dummyID, account);
+
+        assertTrue(result);
+        verify(ipAddressManager, never()).applyIpAssociations(any(), anyBoolean());
+        verify(ipAddressDao).unassignIpAddress(dummyID);
+        verify(annotationDao).removeByEntityType("PUBLIC_IP_ADDRESS", UUID);
+        verify(ipAddressDao).releaseFromLockTable(dummyID);
     }
 
     @Test


### PR DESCRIPTION
Fixes #14068

During VPC teardown, a public IP can retain its associated network ID after the tier's network record has been deleted. `disassociatePublicIpAddress` passes the missing network to `applyIpAssociations`, which dereferences it and aborts VPC deletion with a `NullPointerException`.

Resolve the associated network before choosing the release path. When the network no longer exists, a releasing IP follows the existing quarantine and unassignment path. The association path continues to be used when the network exists.

The regression test supplies a non-null associated network ID whose DAO lookup returns null while the VPC still exists. It verifies successful release, quarantine, IP unassignment, VPC provider cleanup, annotation cleanup and lock release, without calling `applyIpAssociations`. Additional tests cover successful and failed associations when the network exists, and prevent repeated quarantine/unassignment of an already free IP when the network is missing.

This targets `4.22` in accordance with the contribution guide's release-branch policy for bug fixes; the affected code is also present there.

### Validation

- The initial missing-network regression test reproduced `NullPointerException` on the unfixed `4.22` base.
- With the fix and expanded coverage, the complete `IpAddressManagerTest` passes: 30 tests, 0 failures/errors/skips. All 25 selected reactor modules succeed, with 0 Checkstyle violations (JDK 11).
- `git diff --check` passes.

The Maven download plugin could not retrieve the system VM checksum file in this environment. I downloaded the unmodified official `https://download.cloudstack.org/systemvm/4.22/sha512sum.txt` to `engine/schema/dist/systemvm-templates/sha512sum.txt` and ran:

```sh
mvn -B -pl server -am -Dtest=IpAddressManagerTest -Dsurefire.failIfNoSpecifiedTests=false -Ddownload.plugin.skip=true test
```

Only the redundant download was skipped; compilation, Checkstyle and the selected tests ran. No build configuration changes are included.

For an environment-level check, follow the steps in #14068: create a VPC offering with firewall service enabled, deploy a tier and VM, apply a public-IP firewall rule, remove the VM and tier, then destroy the VPC. The VPC should be removed without the missing-network exception and the public IP should be released. This full VPC scenario has not been run locally.
