### PR TITLE
Give a system VM one NIC queue per CPU

### DIFF
--- a/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
+++ b/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
@@ -88,6 +88,8 @@ import com.cloud.vm.dao.VMInstanceDao;
 
 public abstract class HypervisorGuruBase extends AdapterBase implements HypervisorGuru, Configurable {
 
+    private static final int MAX_TAP_QUEUES = 256;
+
     @Inject
     protected
     NicDao nicDao;
@@ -103,8 +105,6 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
     @Inject
     private DataCenterDao dcDao;
     @Inject
-    private static final int MAX_TAP_QUEUES = 256;
-
     private NetworkOfferingDetailsDao networkOfferingDetailsDao;
     @Inject
     protected

--- a/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
+++ b/server/src/main/java/com/cloud/hypervisor/HypervisorGuruBase.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.hypervisor;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -73,6 +74,7 @@ import com.cloud.storage.StoragePool;
 import com.cloud.storage.Volume;
 import com.cloud.utils.Pair;
 import com.cloud.utils.component.AdapterBase;
+import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.NicProfile;
 import com.cloud.vm.NicVO;
 import com.cloud.vm.UserVmManager;
@@ -101,6 +103,8 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
     @Inject
     private DataCenterDao dcDao;
     @Inject
+    private static final int MAX_TAP_QUEUES = 256;
+
     private NetworkOfferingDetailsDao networkOfferingDetailsDao;
     @Inject
     protected
@@ -265,6 +269,34 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
         }
     }
 
+    /**
+     * Gives a system VM one NIC queue per CPU. The guest only ever uses as many queues as it has
+     * CPUs, so this is what the CPU count already implies, and a system VM is only given more CPUs
+     * to move more packets.
+     *
+     * A user VM sets this per VM with deployVirtualMachine or updateVirtualMachine. A system VM
+     * goes through neither, so there is otherwise no way for it to get a queue at all.
+     *
+     * The default offering is a single CPU, so nothing changes until an operator resizes.
+     */
+    protected void addDefaultNicQueuesForSystemVm(VirtualMachineTO to) {
+        if (to.getType() == null || !to.getType().isUsedBySystem()) {
+            return;
+        }
+        Map<String, String> details = to.getDetails();
+        if (details != null && details.containsKey(VmDetailConstants.NIC_MULTIQUEUE_NUMBER)) {
+            return;
+        }
+        // A tap device stops at 256 queues, and the host refuses the VM rather than trimming.
+        int queues = Math.min(to.getCpus(), MAX_TAP_QUEUES);
+        if (queues < 2) {
+            return;
+        }
+        Map<String, String> updated = details == null ? new HashMap<>() : new HashMap<>(details);
+        updated.put(VmDetailConstants.NIC_MULTIQUEUE_NUMBER, String.valueOf(queues));
+        to.setDetails(updated);
+    }
+
     protected VirtualMachineTO toVirtualMachineTO(VirtualMachineProfile vmProfile) {
         ServiceOffering offering = serviceOfferingDao.findById(vmProfile.getId(), vmProfile.getServiceOfferingId());
         VirtualMachine vm = vmProfile.getVirtualMachine();
@@ -331,6 +363,8 @@ public abstract class HypervisorGuruBase extends AdapterBase implements Hypervis
             to.setDetails(detailsInVm);
             addExtraConfig(detailsInVm, to, vm.getAccountId(), vm.getHypervisorType());
         }
+
+        addDefaultNicQueuesForSystemVm(to);
 
         addServiceOfferingExtraConfiguration(offering, to);
 

--- a/server/src/test/java/com/cloud/hypervisor/KVMGuruTest.java
+++ b/server/src/test/java/com/cloud/hypervisor/KVMGuruTest.java
@@ -29,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -51,6 +52,7 @@ import com.cloud.storage.GuestOSVO;
 import com.cloud.storage.dao.GuestOSDao;
 import com.cloud.storage.dao.GuestOSHypervisorDao;
 import com.cloud.utils.Pair;
+import com.cloud.vm.VmDetailConstants;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineProfile;
 
@@ -505,5 +507,81 @@ public class KVMGuruTest {
         Long clusterId = guru.findClusterOfVm(vm);
 
         Assert.assertNull(clusterId);
+    }
+
+    private VirtualMachineTO systemVmTO(int cpus, Map<String, String> details) {
+        VirtualMachineTO to = Mockito.mock(VirtualMachineTO.class);
+        Mockito.when(to.getType()).thenReturn(VirtualMachine.Type.DomainRouter);
+        Mockito.when(to.getCpus()).thenReturn(cpus);
+        Mockito.when(to.getDetails()).thenReturn(details);
+        return to;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> capturedDetails(VirtualMachineTO to) {
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(to).setDetails(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void testSystemVmGetsAQueuePerCpu() {
+        VirtualMachineTO to = systemVmTO(4, null);
+
+        guru.addDefaultNicQueuesForSystemVm(to);
+
+        Assert.assertEquals("4", capturedDetails(to).get(VmDetailConstants.NIC_MULTIQUEUE_NUMBER));
+    }
+
+    @Test
+    public void testSystemVmQueuesStopAtTheTapLimit() {
+        VirtualMachineTO to = systemVmTO(512, null);
+
+        guru.addDefaultNicQueuesForSystemVm(to);
+
+        Assert.assertEquals("256", capturedDetails(to).get(VmDetailConstants.NIC_MULTIQUEUE_NUMBER));
+    }
+
+    @Test
+    public void testSingleCpuSystemVmIsLeftAlone() {
+        VirtualMachineTO to = systemVmTO(1, null);
+
+        guru.addDefaultNicQueuesForSystemVm(to);
+
+        Mockito.verify(to, Mockito.never()).setDetails(Mockito.anyMap());
+    }
+
+    @Test
+    public void testExistingDetailsAreKept() {
+        Map<String, String> existing = new HashMap<>();
+        existing.put(VmDetailConstants.ROOT_DISK_CONTROLLER, "virtio");
+        VirtualMachineTO to = systemVmTO(4, existing);
+
+        guru.addDefaultNicQueuesForSystemVm(to);
+
+        Map<String, String> details = capturedDetails(to);
+        Assert.assertEquals("4", details.get(VmDetailConstants.NIC_MULTIQUEUE_NUMBER));
+        Assert.assertEquals("virtio", details.get(VmDetailConstants.ROOT_DISK_CONTROLLER));
+    }
+
+    @Test
+    public void testAQueueNumberAlreadySetWins() {
+        Map<String, String> set = new HashMap<>();
+        set.put(VmDetailConstants.NIC_MULTIQUEUE_NUMBER, "2");
+        VirtualMachineTO to = systemVmTO(8, set);
+
+        guru.addDefaultNicQueuesForSystemVm(to);
+
+        Mockito.verify(to, Mockito.never()).setDetails(Mockito.anyMap());
+    }
+
+    @Test
+    public void testUserVmsAreNotTouched() {
+        VirtualMachineTO to = Mockito.mock(VirtualMachineTO.class);
+        Mockito.when(to.getType()).thenReturn(VirtualMachine.Type.User);
+
+        guru.addDefaultNicQueuesForSystemVm(to);
+
+        Mockito.verify(to, Mockito.never()).setDetails(Mockito.anyMap());
     }
 }


### PR DESCRIPTION
### Description

A system VM gets one NIC queue no matter how many CPUs it has, so every packet interrupt lands on
CPU0. Adding CPUs to a router therefore does not move more packets, which is the only reason to add
them.

The queue count is already a VM detail, `nic.multiqueue.number`, and the agent already turns it into
`<driver queues='N'/>` on the interface. A user VM can set it three ways:

| how | since |
|---|---|
| `deployVirtualMachine nicmultiqueuenumber=N` | 4.18 |
| `updateVirtualMachine details[0].nic.multiqueue.number=N` | |
| the Settings tab - `listDetailOptions` offers the key for KVM | |

A system VM goes through none of them. It is not created by `deployVirtualMachine`, it is not a
`UserVm` so `updateVirtualMachine` does not apply, and it has no details editor. **There is no way
to set it at all**, which is why this is a fix rather than a new setting.

So a system VM now gets one queue per CPU when nothing is set:

| CPUs | emitted |
|---|---|
| 1 | nothing, identical to today |
| 4 | `queues='4'` |
| 512 | `queues='256'` |

The 256 is the tap device ceiling in the host kernel, which refuses the interface rather than
trimming to fit. Above the CPU count it would make no difference anyway - the guest driver uses
`min(CPUs, queues)` and pushes that at probe, so no guest side change is needed.

A queue number already set on the VM still wins.

**The default offering is a single CPU**, so a default install emits the same domain XML as before.
Only a system VM someone has already resized differs, and it differs in the direction the resize
asked for.

### Worth calling out

- **There is no way to turn this off.** There is no way to turn it on today either, so it is
  symmetric, but it is worth being explicit about on a release branch.
- **The cost scales with NIC count, not just queue count.** A VPC router has one NIC per tier, so a
  4 CPU router fronting 8 tiers goes from 8 vhost threads to 32. Idle queues are cheap, but the
  thread count is not nothing on a dense host.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### How Has This Been Tested?

`KVMGuruTest`, `Tests run: 35, Failures: 0`. Six new cases:

- a 4 CPU system VM gets `queues='4'`
- a 512 CPU one stops at the tap ceiling of 256
- a single CPU one is left alone, so no attribute is emitted
- other details on the VM are preserved
- a queue number already on the VM wins
- a user VM is never touched

The guest side was checked against the driver source the system VM runs, Linux 6.1
`drivers/net/virtio_net.c`:

```c
	/* Enable multiqueue by default */
	if (num_online_cpus() >= max_queue_pairs)
		vi->curr_queue_pairs = max_queue_pairs;
	else
		vi->curr_queue_pairs = num_online_cpus();
```

followed by `virtnet_set_queues(vi, vi->curr_queue_pairs)` at probe, so the queues come up without
`ethtool -L`. The 256 comes from `MAX_TAP_QUEUES` in `drivers/net/tun.c`.
