### PR TITLE
Serialize NIC add/remove on the target VM's work job queue

### DIFF
--- a/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
+++ b/engine/orchestration/src/main/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestrator.java
@@ -237,6 +237,7 @@ import com.cloud.utils.db.SearchCriteria.Op;
 import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionCallbackNoReturn;
+import com.cloud.utils.db.TransactionCallbackWithException;
 import com.cloud.utils.db.TransactionCallbackWithExceptionNoReturn;
 import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
@@ -1139,6 +1140,29 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
         } while (retryIpAllocation);
 
         return vo;
+    }
+
+    /**
+     * Allocate a nic for {@code vm} on {@code network}, choosing its device id atomically.
+     *
+     * {@link NicDao#getFreeDeviceId(long)} picks the first unused device id by reading the vm's
+     * existing nics, but the new nic row is not persisted until the end of {@link #allocateNic}. Two
+     * nics being added to the same vm concurrently (e.g. several tiers of a VPC brought up in parallel,
+     * each attaching the shared redundant VR) would otherwise both read the same free id and land on
+     * the same {@code ethN} — corrupting the VR config and, for a redundant VPC, driving both routers
+     * PRIMARY (issue #11710). Holding the {@code vm_instance} row lock across the read-and-persist makes
+     * the device id assignment atomic per vm.
+     */
+    protected NicProfile allocateNicWithFreeDeviceId(final NicProfile requested, final Network network, final boolean isDefaultNic, final VirtualMachineProfile vm)
+            throws InsufficientCapacityException, ConcurrentOperationException {
+        return Transaction.execute(new TransactionCallbackWithException<NicProfile, InsufficientCapacityException>() {
+            @Override
+            public NicProfile doInTransaction(final TransactionStatus status) throws InsufficientCapacityException {
+                _vmDao.lockRow(vm.getId(), true);
+                final int deviceId = _nicDao.getFreeDeviceId(vm.getId());
+                return allocateNic(requested, network, isDefaultNic, deviceId, vm).first();
+            }
+        });
     }
 
     @DB
@@ -4510,11 +4534,9 @@ public class NetworkOrchestrator extends ManagerBase implements NetworkOrchestra
 
         //1) allocate nic (if needed) Always allocate if it is a user vm
         if (nic == null || vmProfile.getType() == VirtualMachine.Type.User) {
-            final int deviceId = _nicDao.getFreeDeviceId(vm.getId());
+            final boolean isDefaultNic = getNicProfileDefaultNic(requested);
 
-            boolean isDefaultNic = getNicProfileDefaultNic(requested);
-
-            nic = allocateNic(requested, network, isDefaultNic, deviceId, vmProfile).first();
+            nic = allocateNicWithFreeDeviceId(requested, network, isDefaultNic, vmProfile);
 
             if (nic == null) {
                 throw new CloudRuntimeException("Failed to allocate nic for Instance " + vm + " in network " + network);

--- a/engine/orchestration/src/test/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestratorTest.java
+++ b/engine/orchestration/src/test/java/org/apache/cloudstack/engine/orchestration/NetworkOrchestratorTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentMatchers;
+import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -76,6 +77,8 @@ import com.cloud.offerings.NetworkOfferingVO;
 import com.cloud.utils.db.EntityManager;
 import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallback;
+import com.cloud.utils.db.TransactionCallbackWithException;
+import com.cloud.utils.db.TransactionStatus;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.net.Ip;
 import com.cloud.vm.DomainRouterVO;
@@ -88,6 +91,7 @@ import com.cloud.vm.VirtualMachine.Type;
 import com.cloud.vm.VirtualMachineProfile;
 import com.cloud.vm.dao.DomainRouterDao;
 import com.cloud.vm.dao.NicDao;
+import com.cloud.vm.dao.VMInstanceDao;
 import com.cloud.vm.dao.NicExtraDhcpOptionDao;
 import com.cloud.vm.dao.NicIpAliasDao;
 import com.cloud.vm.dao.NicSecondaryIpDao;
@@ -135,6 +139,7 @@ public class NetworkOrchestratorTest extends TestCase {
         testOrchestrator.routerJoinDao = mock(DomainRouterJoinDao.class);
         testOrchestrator._ipAddrMgr = mock(IpAddressManager.class);
         testOrchestrator._entityMgr = mock(EntityManager.class);
+        testOrchestrator._vmDao = mock(VMInstanceDao.class);
         DhcpServiceProvider provider = mock(DhcpServiceProvider.class);
 
         Map<Network.Capability, String> capabilities = new HashMap<Network.Capability, String>();
@@ -1008,6 +1013,45 @@ public class NetworkOrchestratorTest extends TestCase {
             assertEquals(networkRate, nicProfile.getNetworkRate());
             assertFalse(nicProfile.isSecurityGroupEnabled());
             assertEquals("testtag", nicProfile.getName());
+        }
+    }
+
+    @Test
+    public void testAllocateNicWithFreeDeviceIdLocksVmRowBeforeReadingFreeDeviceId() throws Exception {
+        final long vmId = 100L;
+        final int freeDeviceId = 5;
+
+        VirtualMachine vm = mock(VirtualMachine.class);
+        when(vm.getId()).thenReturn(vmId);
+        VirtualMachineProfile vmProfile = mock(VirtualMachineProfile.class);
+        when(vmProfile.getId()).thenReturn(vmId);
+        when(vmProfile.getVirtualMachine()).thenReturn(vm);
+
+        Network network = mock(Network.class);
+        NicProfile requested = mock(NicProfile.class);
+        NicProfile allocated = mock(NicProfile.class);
+
+        when(testOrchestrator._nicDao.getFreeDeviceId(vmId)).thenReturn(freeDeviceId);
+        Mockito.doReturn(new Pair<>(allocated, freeDeviceId)).when(testOrchestrator)
+                .allocateNic(requested, network, false, freeDeviceId, vmProfile);
+
+        try (MockedStatic<Transaction> transactionMocked = Mockito.mockStatic(Transaction.class)) {
+            // run the callback body so the lock/read/allocate ordering is exercised
+            transactionMocked.when(() -> Transaction.execute(any(TransactionCallbackWithException.class)))
+                    .thenAnswer(invocation -> {
+                        TransactionCallbackWithException<NicProfile, InsufficientCapacityException> cb = invocation.getArgument(0);
+                        return cb.doInTransaction(mock(TransactionStatus.class));
+                    });
+
+            NicProfile result = testOrchestrator.allocateNicWithFreeDeviceId(requested, network, false, vmProfile);
+
+            assertEquals(allocated, result);
+            // the vm_instance row must be locked before the free device id is read,
+            // otherwise two concurrent adds pick the same id (issue #11710)
+            InOrder inOrder = Mockito.inOrder(testOrchestrator._vmDao, testOrchestrator._nicDao);
+            inOrder.verify(testOrchestrator._vmDao).lockRow(vmId, true);
+            inOrder.verify(testOrchestrator._nicDao).getFreeDeviceId(vmId);
+            verify(testOrchestrator, times(1)).allocateNic(requested, network, false, freeDeviceId, vmProfile);
         }
     }
 }


### PR DESCRIPTION
### Description

On a redundant VPC, bringing up several tiers with VMs in parallel corrupts both virtual routers' NIC layout. Their keepalived configs diverge and VRRP breaks — the routers end up FAULT or both PRIMARY, and the VPC is unusable until restarted. Root-cause analysis in #11710.

**Cause — a lockless read-then-persist in device id allocation**

`NetworkOrchestrator.createNicForVm()` picks the device id and persists the nic in two separate steps:

```java
int deviceId = _nicDao.getFreeDeviceId(vm.getId());   // reads the vm's existing nics
...
allocateNic(..., deviceId, ...);                        // persists the row much later
```

`getFreeDeviceId()` takes no lock, and the row it is choosing an id for is not written until the end of `allocateNic()`. Two nics added to the same VM concurrently both read the same free id and land on the same `ethN`.

This is triggered when several VPC tiers are created in parallel: each tier attaches the **shared** redundant VR, so N concurrent `createNicForVm()` calls run against one router. Observed `nics` rows for one router during reproduction (all live at once):

| nic id | network | device_id |
|---|---|---|
| 3499 | 300 | **2** |
| 3502 | 301 | **2** |
| 3520 | 302 | **3** |
| 3523 | 303 | **3** |

Two guest nics share one `ethN` (one network blackholed), and because the two routers of a redundant VPC end up with different `device_id → network` maps, their keepalived `virtual_ipaddress` sets diverge → both go PRIMARY.

**Fix**

Compute the free device id and persist the nic under the `vm_instance` row lock, so device id assignment is atomic per VM:

```java
Transaction.execute(... -> {
    _vmDao.lockRow(vm.getId(), true);
    int deviceId = _nicDao.getFreeDeviceId(vm.getId());
    return allocateNic(..., deviceId, ...);
});
```

- Same shape as the existing `persistNicAfterRaceCheck()` IPv4 race guard.
- No change to job dispatch and no new cross-thread waiting. `getFreeDeviceId()`'s only caller is `createNicForVm()`, so this covers the whole device-id race surface — the user-VM add-nic path and the VPC tier attach to the shared VR alike — not just the reported case. (The initial deploy path assigns device ids from a single precomputed set, so it was never exposed to this race.)
- Serializing per router is exactly what the non-concurrent path already does implicitly (one tier at a time).

> This revises the earlier version of this PR, which serialized the three `addVmToNetwork`/`removeNicFromVm`/`removeVmFromNetwork` dispatch sites through the work-job queue. Per review feedback that fixes the symptom downstream and risks a worker-pool stall under a large parallel apply; fixing the allocation at its source is simpler and safer.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Bug Severity

- [ ] BLOCKER
- [x] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### How Has This Been Tested?

**Unit test** — `NetworkOrchestratorTest.testAllocateNicWithFreeDeviceIdLocksVmRowBeforeReadingFreeDeviceId` asserts (via `InOrder`) that the `vm_instance` row is locked *before* `getFreeDeviceId()` is read, and that `allocateNic()` runs with that id. Full suite (59 tests) green.

**Live** — 4.22.1.0, KVM, two management servers, VXLAN, patch deployed on both. Redundant VPC ("VPC HA"), then 8 tiers each with a VM created in parallel via the API (mimics `terraform apply`):

- **Before the fix**: duplicate `device_id`s on a router (two guest NICs on one `ethN`, table above), routers FAULT/PRIMARY.
- **After the fix**: **zero duplicate `device_id`s** on every run — the persistent corruption is gone. Restarting the VPC (the recovery the issue documents) now re-applies both routers to **byte-identical** keepalived configs and a clean BACKUP + PRIMARY election, because there is no longer any duplicated device id to re-render.

Full disclosure on the test environment: its secondary storage was flaky enough that a pristine 8/8 parallel bring-up could not be captured — a couple of VM deploys timed out, and the resulting *partial* application left one router's keepalived missing some gateways, which by itself can still cause a transient dual-PRIMARY on first bring-up. That is a distinct failure mode (a per-router network-apply failure being swallowed while the VPC still reports success — see #11710 discussion) from the device-id race this PR fixes, and is worth a follow-up. What this change is verified to remove is the duplicate-`device_id` corruption that put two networks on one `ethN`.

#### How did you try to break this feature and the system with this change?

- **Lock scope / deadlock**: the lock is the `vm_instance` row of the VM getting the nic (the router). It is held across `allocateNic()`, which acquires only leaf locks (IP address rows) — consistent `vm → ip` ordering, no inversion. `implementNetwork()`'s network op-lock is taken *after* allocation, outside this transaction. The router being attached is already running, so it is never being started concurrently under its own row lock.
- **Contention**: concurrent tier attaches to one router now serialize — which is required for correctness and matches the non-concurrent path. Different VMs/routers lock different rows and proceed in parallel.
- **Exception behaviour**: unchanged — `allocateNic`'s `InsufficientCapacity`/`ConcurrentOperation` exceptions propagate as before (the callback's `throws` widens to `InsufficientCapacityException`, already declared by `createNicForVm`).
