### PR TITLE
server: compare the root admin resource limit against unlimited as a long

### DIFF
--- a/server/src/main/java/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
+++ b/server/src/main/java/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
@@ -931,7 +931,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
             }
 
             //only Unlimited value is accepted if account is  Root Admin
-            if (_accountMgr.isRootAdmin(account.getId()) && max.shortValue() != Resource.RESOURCE_UNLIMITED) {
+            if (_accountMgr.isRootAdmin(account.getId()) && max != Resource.RESOURCE_UNLIMITED) {
                 throw new InvalidParameterValueException("Only " + Resource.RESOURCE_UNLIMITED + " limit is supported for Root Admin accounts");
             }
 

--- a/server/src/test/java/com/cloud/resourcelimit/ResourceLimitManagerImplTest.java
+++ b/server/src/test/java/com/cloud/resourcelimit/ResourceLimitManagerImplTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.cloudstack.api.response.AccountResponse;
 import org.apache.cloudstack.api.response.DomainResponse;
 import org.apache.cloudstack.api.response.TaggedResourceLimitAndCountResponse;
+import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.reservation.dao.ReservationDao;
 import org.apache.cloudstack.resourcelimit.Reserver;
@@ -57,6 +58,7 @@ import com.cloud.configuration.dao.ResourceLimitDao;
 import com.cloud.domain.Domain;
 import com.cloud.domain.DomainVO;
 import com.cloud.domain.dao.DomainDao;
+import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.offering.DiskOffering;
 import com.cloud.offering.ServiceOffering;
@@ -73,8 +75,10 @@ import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
 import com.cloud.user.AccountVO;
 import com.cloud.user.ResourceLimitService;
+import com.cloud.user.User;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.Pair;
+import com.cloud.utils.db.EntityManager;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineManager;
 import com.cloud.vm.dao.UserVmDao;
@@ -123,6 +127,8 @@ public class ResourceLimitManagerImplTest extends TestCase {
     UserVmDao userVmDao;
     @Mock
     SnapshotDataStoreDao snapshotDataStoreDao;
+    @Mock
+    EntityManager entityManager;
 
     private List<String> hostTags = List.of("htag1", "htag2", "htag3");
     private List<String> storageTags = List.of("stag1", "stag2");
@@ -1177,5 +1183,23 @@ public class ResourceLimitManagerImplTest extends TestCase {
                 offering, Mockito.mock(VirtualMachineTemplate.class), null);
         Mockito.verify(resourceLimitManager, Mockito.times(1))
                 .decrementResourceCountWithTag(accountId, Resource.ResourceType.memory, tag, Long.valueOf(memory));
+    }
+
+    @Test
+    public void updateResourceLimitRejectsAFiniteLimitForRootAdminEvenWhenItsLowBitsLookUnlimited() {
+        long rootAdminAccountId = 2L;
+        Account rootAdmin = Mockito.mock(Account.class);
+        Mockito.when(rootAdmin.getId()).thenReturn(rootAdminAccountId);
+        Mockito.when(entityManager.findById(Account.class, rootAdminAccountId)).thenReturn(rootAdmin);
+        Mockito.when(accountManager.isRootAdmin(rootAdminAccountId)).thenReturn(true);
+
+        CallContext.register(Mockito.mock(User.class), rootAdmin);
+        try {
+            InvalidParameterValueException e = Assert.assertThrows(InvalidParameterValueException.class, () ->
+                    resourceLimitManager.updateResourceLimit(rootAdminAccountId, null, Resource.ResourceType.user_vm.getOrdinal(), 65535L, null));
+            Assert.assertEquals("Only -1 limit is supported for Root Admin accounts", e.getMessage());
+        } finally {
+            CallContext.unregister();
+        }
     }
 }


### PR DESCRIPTION
### Description

updateResourceLimit only accepts -1 (unlimited) for a root admin account, but the check compared `max.shortValue() != Resource.RESOURCE_UNLIMITED`. `max` is a Long, so `shortValue()` keeps only the low 16 bits, and any limit whose low 16 bits are all ones (65535, 131071, ...) truncates to -1. Such a value gets past the "Only -1 limit is supported for Root Admin accounts" check and is stored on the root admin account, while an ordinary value like 100 is rejected as expected. This compares the full value instead.

The same code is on 4.20, 4.22 and main, so this targets 4.20.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Added `updateResourceLimitRejectsAFiniteLimitForRootAdminEvenWhenItsLowBitsLookUnlimited` to `ResourceLimitManagerImplTest`. It calls updateResourceLimit for a root admin account with 65535 and expects the "Only -1 limit" rejection. It fails against the current code (the update goes through) and passes with the fix, and the rest of `ResourceLimitManagerImplTest` (56 tests) passes.

    mvn -pl server test -Dtest=ResourceLimitManagerImplTest

Also verified on a live 4.23 KVM environment with the same one line change, calling updateResourceLimit through the API for the root admin account `admin` (resourcetype 0, user VMs).

Before the change, 65535 is accepted and stored on the root admin account, while 100 is rejected:

    22:07:06 command=updateResourceLimit&account=admin&resourcetype=0&max=65535  HTTP/1.1 200  "max":65535
    22:07:06 command=updateResourceLimit&account=admin&resourcetype=0&max=100    HTTP/1.1 431  Only -1 limit is supported for Root Admin accounts
    22:07:06 command=updateResourceLimit&account=admin&resourcetype=0&max=-1     HTTP/1.1 200

With the change, 65535 is rejected like any other finite value, and -1 is still accepted:

    22:08:04 command=updateResourceLimit&account=admin&resourcetype=0&max=65535  HTTP/1.1 431  Only -1 limit is supported for Root Admin accounts
    22:08:04 command=updateResourceLimit&account=admin&resourcetype=0&max=100    HTTP/1.1 431  Only -1 limit is supported for Root Admin accounts
    22:08:04 command=updateResourceLimit&account=admin&resourcetype=0&max=-1     HTTP/1.1 200

#### How did you try to break this feature and the system with this change?

-1 is still accepted for root admin accounts, values that were already rejected stay rejected, and limits for accounts that are not root admins are not affected since this check only runs for root admins.
