### PR TITLE
server: fix operator precedence in the updateResourceLimit own-domain guard

### DIFF
--- a/server/src/main/java/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
+++ b/server/src/main/java/com/cloud/resourcelimit/ResourceLimitManagerImpl.java
@@ -966,7 +966,7 @@ public class ResourceLimitManagerImpl extends ManagerBase implements ResourceLim
                 throw new PermissionDeniedException("Cannot update resource limit for ROOT domain " + domainId + ", permission denied");
             }
 
-            if ((caller.getDomainId() == domainId) && caller.getType() == Account.Type.DOMAIN_ADMIN || caller.getType() == Account.Type.RESOURCE_DOMAIN_ADMIN) {
+            if ((caller.getDomainId() == domainId) && (caller.getType() == Account.Type.DOMAIN_ADMIN || caller.getType() == Account.Type.RESOURCE_DOMAIN_ADMIN)) {
                 // if the admin is trying to update their own domain, disallow...
                 throw new PermissionDeniedException("Unable to update resource limit for domain " + domainId + ", permission denied");
             }

--- a/server/src/test/java/com/cloud/resourcelimit/ResourceLimitManagerImplTest.java
+++ b/server/src/test/java/com/cloud/resourcelimit/ResourceLimitManagerImplTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.cloudstack.api.response.AccountResponse;
 import org.apache.cloudstack.api.response.DomainResponse;
 import org.apache.cloudstack.api.response.TaggedResourceLimitAndCountResponse;
+import org.apache.cloudstack.context.CallContext;
 import org.apache.cloudstack.framework.config.ConfigKey;
 import org.apache.cloudstack.reservation.dao.ReservationDao;
 import org.apache.cloudstack.resourcelimit.Reserver;
@@ -57,6 +58,7 @@ import com.cloud.configuration.dao.ResourceLimitDao;
 import com.cloud.domain.Domain;
 import com.cloud.domain.DomainVO;
 import com.cloud.domain.dao.DomainDao;
+import com.cloud.exception.PermissionDeniedException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.offering.DiskOffering;
 import com.cloud.offering.ServiceOffering;
@@ -73,8 +75,10 @@ import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
 import com.cloud.user.AccountVO;
 import com.cloud.user.ResourceLimitService;
+import com.cloud.user.User;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.utils.Pair;
+import com.cloud.utils.db.EntityManager;
 import com.cloud.vm.VirtualMachine;
 import com.cloud.vm.VirtualMachineManager;
 import com.cloud.vm.dao.UserVmDao;
@@ -123,6 +127,8 @@ public class ResourceLimitManagerImplTest extends TestCase {
     UserVmDao userVmDao;
     @Mock
     SnapshotDataStoreDao snapshotDataStoreDao;
+    @Mock
+    EntityManager entityManager;
 
     private List<String> hostTags = List.of("htag1", "htag2", "htag3");
     private List<String> storageTags = List.of("stag1", "stag2");
@@ -1177,5 +1183,47 @@ public class ResourceLimitManagerImplTest extends TestCase {
                 offering, Mockito.mock(VirtualMachineTemplate.class), null);
         Mockito.verify(resourceLimitManager, Mockito.times(1))
                 .decrementResourceCountWithTag(accountId, Resource.ResourceType.memory, tag, Long.valueOf(memory));
+    }
+
+    private Account mockResourceDomainAdmin(long domainId) {
+        Account resourceDomainAdmin = Mockito.mock(Account.class);
+        Mockito.when(resourceDomainAdmin.getDomainId()).thenReturn(domainId);
+        Mockito.when(resourceDomainAdmin.getType()).thenReturn(Account.Type.RESOURCE_DOMAIN_ADMIN);
+        return resourceDomainAdmin;
+    }
+
+    @Test
+    public void updateResourceLimitAllowsAResourceDomainAdminToUpdateASubdomain() {
+        long ownDomainId = 5L;
+        long subdomainId = 7L;
+        Domain subdomain = Mockito.mock(Domain.class);
+        Mockito.when(subdomain.getParent()).thenReturn(ownDomainId);
+        Mockito.when(entityManager.findById(Domain.class, subdomainId)).thenReturn(subdomain);
+        DomainVO ownDomain = Mockito.mock(DomainVO.class);
+        Mockito.when(domainDao.findById(ownDomainId)).thenReturn(ownDomain);
+        Mockito.doReturn((long) Resource.RESOURCE_UNLIMITED).when(resourceLimitManager)
+                .findCorrectResourceLimitForDomain(ownDomain, Resource.ResourceType.user_vm, null);
+
+        CallContext.register(Mockito.mock(User.class), mockResourceDomainAdmin(ownDomainId));
+        try {
+            resourceLimitManager.updateResourceLimit(null, subdomainId, Resource.ResourceType.user_vm.getOrdinal(), 10L, null);
+        } finally {
+            CallContext.unregister();
+        }
+        Mockito.verify(resourceLimitDao).persist(Mockito.any(ResourceLimitVO.class));
+    }
+
+    @Test
+    public void updateResourceLimitDeniesAResourceDomainAdminOnTheirOwnDomain() {
+        long ownDomainId = 5L;
+        Mockito.when(entityManager.findById(Domain.class, ownDomainId)).thenReturn(Mockito.mock(Domain.class));
+
+        CallContext.register(Mockito.mock(User.class), mockResourceDomainAdmin(ownDomainId));
+        try {
+            Assert.assertThrows(PermissionDeniedException.class, () ->
+                    resourceLimitManager.updateResourceLimit(null, ownDomainId, Resource.ResourceType.user_vm.getOrdinal(), 10L, null));
+        } finally {
+            CallContext.unregister();
+        }
     }
 }


### PR DESCRIPTION
### Description

The domain branch guard in updateResourceLimit is `ownDomain && type == DOMAIN_ADMIN || type == RESOURCE_DOMAIN_ADMIN`. Since `&&` binds tighter than `||`, a resource domain admin is denied updating the limits of every domain, including its own sub-domains ("Unable to update resource limit for domain X, permission denied"). The intent, like the account branch just above it, is only to block an admin on its own domain. This adds the missing parentheses.

Resource domain admins exist only in domains that own a private zone, so this affects those setups. The own domain rule is unchanged, and so is the own account rule discussed in #10922. The same code is on 4.20, 4.22 and main, so this targets 4.20.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Added two tests to ResourceLimitManagerImplTest: a resource domain admin updating a sub-domain (fails before with PermissionDeniedException, passes after) and the same admin on its own domain (denied before and after). The class passes (57 tests).

Also verified on a live 4.23 KVM environment with the same change: domain /rl-live with sub-domain /rl-live/rl-live-sub, and a Resource Admin account rladmin in /rl-live calling updateResourceLimit (user VMs, max 10).

Before:

    rl-live-sub  531 Unable to update resource limit for domain 5, permission denied
    rl-live      531 Unable to update resource limit for domain 4, permission denied

After:

    rl-live-sub  200 {"resourcelimit":{"domain":"rl-live-sub",...,"max":10}}
    rl-live      531 Unable to update resource limit for domain 4, permission denied

#### How did you try to break this feature and the system with this change?

Domain admins and root admins behave exactly as before, and both admin types are still denied on their own domain. A resource domain admin on another domain still has to pass checkAccess and the parent domain limit check, so it cannot reach domains outside its tree.
