### PR TITLE
server: keep collecting VM network stats after a non DirectAttached NIC

### DIFF
--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -5019,7 +5019,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
                             List<VlanVO> vlan = _vlanDao.listVlansByNetworkId(nic.getNetworkId());
                             if (vlan == null || vlan.size() == 0 || vlan.get(0).getVlanType() != VlanType.DirectAttached)
                             {
-                                break; // only get network statistics for DirectAttached network (shared networks in Basic zone and Advanced zone with/without SG)
+                                continue; // only get network statistics for DirectAttached network (shared networks in Basic zone and Advanced zone with/without SG)
                             }
                             UserStatisticsVO previousvmNetworkStats = _userStatsDao.findBy(userVm.getAccountId(), userVm.getDataCenterId(), nic.getNetworkId(), nic.getIPv4Address(), userVm.getId(), "UserVm");
                             if (previousvmNetworkStats == null) {

--- a/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
+++ b/server/src/test/java/com/cloud/vm/UserVmManagerImplTest.java
@@ -77,12 +77,19 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.cloud.agent.AgentManager;
+import com.cloud.agent.api.GetVmNetworkStatsAnswer;
+import com.cloud.agent.api.GetVmNetworkStatsCommand;
+import com.cloud.agent.api.VmNetworkStatsEntry;
 import com.cloud.api.query.dao.ServiceOfferingJoinDao;
 import com.cloud.api.query.vo.ServiceOfferingJoinVO;
 import com.cloud.configuration.Resource;
 import com.cloud.dc.DataCenter;
 import com.cloud.dc.DataCenterVO;
+import com.cloud.dc.Vlan;
+import com.cloud.dc.VlanVO;
 import com.cloud.dc.dao.DataCenterDao;
+import com.cloud.dc.dao.VlanDao;
 import com.cloud.deploy.DataCenterDeployment;
 import com.cloud.deploy.DeployDestination;
 import com.cloud.deploy.DeploymentPlanner;
@@ -151,13 +158,18 @@ import com.cloud.user.AccountVO;
 import com.cloud.user.ResourceLimitService;
 import com.cloud.user.UserData;
 import com.cloud.user.UserDataVO;
+import com.cloud.user.UserStatisticsVO;
 import com.cloud.user.UserVO;
 import com.cloud.user.dao.AccountDao;
 import com.cloud.user.dao.UserDao;
 import com.cloud.user.dao.UserDataDao;
+import com.cloud.user.dao.UserStatisticsDao;
 import com.cloud.uservm.UserVm;
 import com.cloud.utils.Pair;
 import com.cloud.utils.db.EntityManager;
+import com.cloud.utils.db.SearchCriteria;
+import com.cloud.utils.db.Transaction;
+import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.exception.ExceptionProxyObject;
 import com.cloud.vm.dao.NicDao;
@@ -262,6 +274,15 @@ public class UserVmManagerImplTest {
 
     @Mock
     HostDao hostDao;
+
+    @Mock
+    AgentManager agentManager;
+
+    @Mock
+    VlanDao vlanDao;
+
+    @Mock
+    UserStatisticsDao userStatsDao;
 
     @Mock
     private VolumeVO volumeVOMock;
@@ -3200,5 +3221,51 @@ public class UserVmManagerImplTest {
 
         Assert.assertEquals(Long.valueOf(500L), volume.getMinIops());
         Assert.assertEquals(Long.valueOf(2000L), volume.getMaxIops());
+    }
+
+    @Test
+    public void collectVmNetworkStatisticsSkipsANonDirectAttachedNicAndStillUpdatesTheNextOne() {
+        long hostId = 1L;
+        String vmName = "i-2-3-VM";
+        Mockito.when(userVmVoMock.getHypervisorType()).thenReturn(Hypervisor.HypervisorType.KVM);
+        Mockito.when(userVmVoMock.getHostId()).thenReturn(hostId);
+        Mockito.when(userVmVoMock.getInstanceName()).thenReturn(vmName);
+        Mockito.when(hostDao.findById(hostId)).thenReturn(Mockito.mock(HostVO.class));
+
+        HashMap<String, List<VmNetworkStatsEntry>> statsByVm = new HashMap<>();
+        statsByVm.put(vmName, List.of(new VmNetworkStatsEntry(vmName, "02:00:00:00:00:01", 100L, 200L),
+                new VmNetworkStatsEntry(vmName, "02:00:00:00:00:02", 300L, 400L)));
+        GetVmNetworkStatsAnswer answer = Mockito.mock(GetVmNetworkStatsAnswer.class);
+        Mockito.when(answer.getResult()).thenReturn(true);
+        Mockito.when(answer.getVmNetworkStatsMap()).thenReturn(statsByVm);
+        Mockito.when(agentManager.easySend(Mockito.eq(hostId), Mockito.any(GetVmNetworkStatsCommand.class))).thenReturn(answer);
+
+        NicVO isolatedNic = Mockito.mock(NicVO.class);
+        Mockito.when(isolatedNic.getNetworkId()).thenReturn(10L);
+        NicVO sharedNic = Mockito.mock(NicVO.class);
+        Mockito.when(sharedNic.getNetworkId()).thenReturn(20L);
+        SearchCriteria<NicVO> nicSearch = Mockito.mock(SearchCriteria.class);
+        Mockito.when(nicDao.createSearchCriteria()).thenReturn(nicSearch);
+        Mockito.when(nicDao.search(nicSearch, null)).thenReturn(List.of(isolatedNic), List.of(sharedNic));
+
+        VlanVO directAttachedVlan = Mockito.mock(VlanVO.class);
+        Mockito.when(directAttachedVlan.getVlanType()).thenReturn(Vlan.VlanType.DirectAttached);
+        Mockito.when(vlanDao.listVlansByNetworkId(10L)).thenReturn(new ArrayList<>());
+        Mockito.when(vlanDao.listVlansByNetworkId(20L)).thenReturn(List.of(directAttachedVlan));
+
+        UserStatisticsVO sharedNicStatistics = Mockito.mock(UserStatisticsVO.class);
+        Mockito.when(userStatsDao.findBy(Mockito.anyLong(), Mockito.anyLong(), Mockito.eq(20L), Mockito.nullable(String.class), Mockito.anyLong(), Mockito.eq("UserVm")))
+                .thenReturn(sharedNicStatistics);
+        Mockito.when(userStatsDao.lock(Mockito.anyLong(), Mockito.anyLong(), Mockito.eq(20L), Mockito.nullable(String.class), Mockito.anyLong(), Mockito.eq("UserVm")))
+                .thenReturn(sharedNicStatistics);
+
+        try (MockedStatic<Transaction> transaction = Mockito.mockStatic(Transaction.class)) {
+            transaction.when(() -> Transaction.execute(Mockito.any(TransactionCallback.class)))
+                    .thenAnswer(invocation -> ((TransactionCallback<?>) invocation.getArgument(0)).doInTransaction(null));
+            userVmManagerImpl.collectVmNetworkStatistics(userVmVoMock);
+        }
+
+        Mockito.verify(sharedNicStatistics).setCurrentBytesSent(300L);
+        Mockito.verify(userStatsDao).update(Mockito.anyLong(), Mockito.eq(sharedNicStatistics));
     }
 }


### PR DESCRIPTION
### Description

When a KVM VM is stopped, collectVmNetworkStatistics records usage for its NICs on DirectAttached (shared) networks. For a NIC on any other network it ran `break`, which ends the whole loop, so a shared network NIC ordered after an isolated one never gets its statistics recorded. The comment says the intent is to skip only that NIC, so this changes `break` to `continue`.

The same code is on 4.20, 4.22 and main, so this targets 4.20.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Added a test to UserVmManagerImplTest that feeds collectVmNetworkStatistics stats for an isolated NIC followed by a shared network NIC and checks the shared NIC's user_statistics row is updated. It fails against the current code and passes with the fix. The class passes (182 tests).

Also verified on a live 4.23 KVM environment with the same change: a VM with NIC 0 on an isolated network and NIC 1 on a shared network (192.16.98.4), running a few minutes and then stopped.

Before, the stop runs the collection but writes nothing for the shared NIC:

    Collect vm network statistics from host before stopping Vm
    user_statistics for the VM: (no rows)

After, the shared NIC's usage is recorded on stop:

    Collect vm network statistics from host before stopping Vm
    user_statistics for the VM: network 231 (shared), 192.16.98.4, bytes received 320

#### How did you try to break this feature and the system with this change?

NICs on networks that are not DirectAttached are still skipped, and a VM whose NICs are all on shared networks behaves as before. Only the NICs after the first skipped one are affected, which now get their statistics recorded.
