### PR TITLE
ui: improve related global config popup

### DIFF
--- a/ui/public/locales/en.json
+++ b/ui/public/locales/en.json
@@ -3942,6 +3942,7 @@
 "message.recover.vm": "Please confirm that you would like to recover this Instance.",
 "message.reinstall.vm": "NOTE: Proceed with caution. This will cause the Instance to be reinstalled from the Template; data on the root disk will be lost. Extra data volumes, if any, will not be touched.",
 "message.related.settings.changed": "'%x' has been changed. Would you like to review or update any related settings below?",
+"message.related.settings.may.not.be.exhaustive": "This list of related settings may not be exhaustive. Please check the documentation for other settings that may need to be updated.",
 "message.release.ip.failed": "Failed to release IP",
 "message.releasing.dedicated.cluster": "Releasing dedicated Cluster...",
 "message.releasing.dedicated.host": "Releasing dedicated host...",

--- a/ui/src/views/setting/ConfigurationValue.vue
+++ b/ui/src/views/setting/ConfigurationValue.vue
@@ -199,6 +199,11 @@
       :width="'60vw'"
       @cancel="closeRelatedModal">
       <p>{{ $t('message.related.settings.changed').replace('%x', relatedSourceConfigName) }}</p>
+      <a-alert
+        type="info"
+        showIcon
+        style="margin-bottom: 12px"
+        :message="$t('message.related.settings.may.not.be.exhaustive')" />
       <a-table
         size="small"
         :showHeader="false"
@@ -396,22 +401,37 @@ export default {
     },
     fetchRelatedConfigurations (configrecord) {
       const prefix = this.getRelatedConfigPrefix(configrecord)
-      if (!prefix) {
-        return
-      }
-      this.relatedLoading = true
-      const params = {
+      const scopeParams = {
         [this.scopeKey]: this.$route.params?.id,
-        keyword: prefix,
         pagesize: -1,
         listAll: true
       }
-      if (this.scopeKey === 'domainid' && !params[this.scopeKey]) {
-        params[this.scopeKey] = this.resource?.id
+      if (this.scopeKey === 'domainid' && !scopeParams[this.scopeKey]) {
+        scopeParams[this.scopeKey] = this.resource?.id
       }
-      getAPI('listConfigurations', params).then(json => {
-        const list = json?.listconfigurationsresponse?.configuration || []
-        this.relatedConfigs = list.filter(c => c.name !== configrecord.name && c.name.startsWith(prefix + '.'))
+      const requests = []
+      if (prefix) {
+        requests.push(
+          getAPI('listConfigurations', { ...scopeParams, keyword: prefix }).then(json => {
+            const list = json?.listconfigurationsresponse?.configuration || []
+            return list.filter(c => c.name.startsWith(prefix + '.'))
+          })
+        )
+      }
+      requests.push(
+        getAPI('listConfigurations', { ...scopeParams, parent: configrecord.name }).then(json => {
+          return json?.listconfigurationsresponse?.configuration || []
+        })
+      )
+      this.relatedLoading = true
+      Promise.all(requests).then(results => {
+        const merged = new Map()
+        results.flat().forEach(c => {
+          if (c.name !== configrecord.name) {
+            merged.set(c.name, c)
+          }
+        })
+        this.relatedConfigs = Array.from(merged.values())
         if (this.relatedConfigs.length > 0) {
           this.relatedSourceConfigName = configrecord.name
           this.relatedModalVisible = true


### PR DESCRIPTION
### Description
Follow-up for https://github.com/apache/cloudstack/pull/13965
Consider child configs in the list for related configs and show an alert that there may be other dependent configs.
Apart from prefix matching, now it also lists configs with `parent` param.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

https://github.com/user-attachments/assets/448ed3f8-c6c3-4d88-badd-cca5eeb2f683




### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
