### PR TITLE
server: remove user-project mappings when delete a project

### DIFF
--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDao.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDao.java
@@ -31,7 +31,7 @@ public interface ProjectAccountDao extends GenericDao<ProjectAccountVO, Long> {
 
     ProjectAccountVO findByProjectIdAccountId(long projectId, long accountId);
 
-    ProjectAccountVO findByProjectIdUserId(long projectId, long accountId, long userId);
+    ProjectAccountVO findByProjectIdUserId(long projectId, long accountId, Long userId);
 
     boolean canUserAccessProjectAccount(long accountId, long userId, long projectAccountId);
 

--- a/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/projects/dao/ProjectAccountDaoImpl.java
@@ -108,10 +108,12 @@ public class ProjectAccountDaoImpl extends GenericDaoBase<ProjectAccountVO, Long
     }
 
     @Override
-    public ProjectAccountVO findByProjectIdUserId(long projectId, long accountId, long userId) {
+    public ProjectAccountVO findByProjectIdUserId(long projectId, long accountId, Long userId) {
         SearchCriteria<ProjectAccountVO> sc = AllFieldsSearch.create();
         sc.setParameters("projectId", projectId);
-        sc.setParameters("userId", userId);
+        if (userId != null) {
+            sc.setParameters("userId", userId);
+        }
         sc.setParameters("accountId", accountId);
 
         return findOneBy(sc);

--- a/server/src/main/java/com/cloud/projects/ProjectManagerImpl.java
+++ b/server/src/main/java/com/cloud/projects/ProjectManagerImpl.java
@@ -449,7 +449,7 @@ public class ProjectManagerImpl extends ManagerBase implements ProjectManager, C
 
     @Override
     public boolean unassignAccountFromProject(long projectId, long accountId) {
-        ProjectAccountVO projectAccount = _projectAccountDao.findByProjectIdAccountId(projectId, accountId);
+        ProjectAccountVO projectAccount = _projectAccountDao.findByProjectIdUserId(projectId, accountId, null);
         if (projectAccount == null) {
             logger.debug("Account id=" + accountId + " is not assigned to project id=" + projectId + " so no need to unassign");
             return true;


### PR DESCRIPTION
### Description

This PR fixes #12601

When an account is added to a project with a project role (e.g. via addUserToProject), the resulting project_account row has a non-null user_id. Project cleanup (deleteProject ... cleanup=true) unassigns every account from the project via ProjectAccountDaoImpl#findByProjectIdUserId(projectId, accountId, null), expecting a null userId to mean "match this account regardless of which user_id the row has".

 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ******************************************************************************* -->
<!--- NOTE: AUTOMATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ******************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

### How Has This Been Tested?

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->

Verified on a live 2-node management server deployment:

- Built and deployed the patched jar to both management nodes.
- Reproduced the original issue with the pre-fix code: created an account, created a project, added the account's user to the project with addUserToProject roletype=Admin (producing a project_account row with a non-null user_id), deleted the project with cleanup=true (reported success), then attempted deleteAccount — reproduced the exact errorcode 431 failure from #12601.
- Repeated the same steps against the fixed jar: deleteProject cleanup=true followed by deleteAccount both succeeded, and the account no longer appeared in listAccounts.
- Confirmed both management nodes ended up running the identical fixed build.

#### How did you try to break this feature and the system with this change?

<!-- see how your change affects other areas of the code, etc. -->

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document -->
