### PR TITLE
kvm: set LIBVIRTD_ARGS so libvirtd listens on Debian and Ubuntu hosts

### DIFF
--- a/python/lib/cloudutils/serviceConfig.py
+++ b/python/lib/cloudutils/serviceConfig.py
@@ -722,6 +722,7 @@ class libvirtConfigUbuntu(serviceCfgBase):
         elif os.path.exists("/etc/default/libvirtd"):
             cfo = configFileOps("/etc/default/libvirtd", self)
             cfo.replace_or_add_line("libvirtd_opts=","libvirtd_opts='-l'")
+            cfo.replace_or_add_line("LIBVIRTD_ARGS=","LIBVIRTD_ARGS=\"--listen\"")
             if os.path.exists("/lib/systemd/system/libvirtd.socket"):
                 bash("/bin/systemctl mask \
                     libvirtd.socket \


### PR DESCRIPTION
### Description

cloudstack-setup-agent sets up live migration on Debian and Ubuntu by writing `libvirtd_opts='-l'` to /etc/default/libvirtd and masking the libvirtd sockets. The libvirtd.service unit on current releases reads `LIBVIRTD_ARGS` from that file instead (Debian 12 and 13: `ExecStart=/usr/sbin/libvirtd $LIBVIRTD_ARGS` with `--timeout 120` as the default), so after adding a host libvirtd runs without `--listen`, nothing listens on 16509/16514 and live migration fails. This also sets `LIBVIRTD_ARGS="--listen"`, and keeps `libvirtd_opts` for older units that still read it.

Related: #9802 and #12374.

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI
- [ ] test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [x] Major
- [ ] Minor
- [ ] Trivial

### Screenshots (if appropriate):

N/A

### How Has This Been Tested?

Live tested on two fresh Debian 13 KVM hosts (libvirt 11.3, QEMU 10.0) added to a cluster with addHost, with NFS primary storage, and a VM live migrated between them with migrateVirtualMachine.

Before this change, right after addHost:

    /etc/default/libvirtd   libvirtd_opts='-l'
    libvirtd process        /usr/sbin/libvirtd --timeout 120
    ports 16509/16514       nothing listening

    15:51:27 GET command=migrateVirtualMachine&virtualmachineid=...&hostid=...
    15:51:28 ERROR [LibvirtMigrateCommandWrapper] Can't migrate domain due to: [unable to connect to server at '<destination host>:16509': Connection refused]
    15:51:28 Complete async job-1640, jobStatus: FAILED, resultCode: 530, "Failed to migrate domain"

With this change, same hosts reset to the distro defaults and added again:

    /etc/default/libvirtd   libvirtd_opts='-l'
                            LIBVIRTD_ARGS="--listen"
    libvirtd process        /usr/sbin/libvirtd --listen
    port 16514              listening

    15:58:25 GET command=migrateVirtualMachine&virtualmachineid=...&hostid=...
    15:58:28 Complete async job-1653, jobStatus: SUCCEEDED

Debian 12 (libvirt 9.0) uses the same unit layout.

#### How did you try to break this feature and the system with this change?

Older units that read libvirtd_opts still get it. replace_or_add_line replaces an existing or commented LIBVIRTD_ARGS line, so adding a host again does not duplicate it. The RHEL and SUSE paths are unchanged.
