### PR TITLE
ui: show project instance volumes in default view

### DIFF
--- a/ui/src/components/view/VolumesTab.vue
+++ b/ui/src/components/view/VolumesTab.vue
@@ -132,7 +132,7 @@ export default {
       }
     },
     getVolumes () {
-      getAPI('listVolumes', { listall: true, listsystemvms: true, virtualmachineid: this.vm.id }).then(json => {
+      getAPI('listVolumes', { listall: true, listsystemvms: true, projectid: '-1', virtualmachineid: this.vm.id }).then(json => {
         this.volumes = json.listvolumesresponse.volume
         if (this.volumes) {
           this.volumes.sort((a, b) => { return a.deviceid - b.deviceid })

--- a/ui/tests/unit/components/view/VolumesTab.spec.js
+++ b/ui/tests/unit/components/view/VolumesTab.spec.js
@@ -15,13 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { createServer } from 'http'
 import { flushPromises } from '@vue/test-utils'
 
-import mockAxios from '../../../mock/mockAxios'
 import common from '../../../common'
 import VolumesTab from '@/components/view/VolumesTab.vue'
+import { axios } from '@/utils/request'
+import { CURRENT_PROJECT } from '@/store/mutation-types'
+import { vueProps } from '@/vue-app'
 
-jest.mock('axios', () => mockAxios)
 jest.mock('@/vue-app', () => ({
   vueProps: {
     $localStorage: {
@@ -32,10 +34,43 @@ jest.mock('@/vue-app', () => ({
 
 const router = common.createMockRouter()
 const i18n = common.createMockI18n('en')
+const projectVm = { id: 'vm-1', projectid: 'project-1' }
+const accountVm = { id: 'vm-2' }
+const systemVm = { id: 'vm-3', systemvmtype: 'secondarystoragevm' }
+let requests = []
+const server = createServer((request, response) => {
+  const params = Object.fromEntries(new URL(request.url, 'http://localhost').searchParams)
+  requests.push(params)
+  const vm = [projectVm, accountVm, systemVm].find(vm => vm.id === params.virtualmachineid)
+  const volume = vm && (
+    (params.projectid === '-1' && params.listall === 'true') ||
+    params.projectid === vm.projectid
+  )
+    ? [
+      { id: 'data-volume', name: 'Data volume', deviceid: 1 },
+      { id: 'root-volume', name: 'Root volume', deviceid: 0 }
+    ]
+    : []
+  response.setHeader('Content-Type', 'application/json')
+  response.end(JSON.stringify({ listvolumesresponse: { count: volume.length, volume } }))
+})
 
 describe('Components > View > VolumesTab.vue', () => {
+  beforeAll(async () => {
+    await new Promise((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    axios.defaults.baseURL = `http://127.0.0.1:${server.address().port}`
+    axios.defaults.adapter = require('axios/lib/adapters/http')
+  })
+
+  afterAll(() => new Promise(resolve => server.close(resolve)))
+
   beforeEach(() => {
+    requests = []
     jest.clearAllMocks()
+    vueProps.$localStorage.get.mockReturnValue(null)
     jest.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
@@ -63,23 +98,32 @@ describe('Components > View > VolumesTab.vue', () => {
 
     expect(wrapper.text()).toContain('2.00 GiB')
     expect(wrapper.text()).not.toContain('2.00 GB')
-    expect(mockAxios).not.toHaveBeenCalled()
+    expect(requests).toHaveLength(0)
 
     wrapper.unmount()
   })
 
   it.each([
-    ['project instance', { id: 'vm-1', projectid: 'project-1' }],
-    ['account instance', { id: 'vm-2' }],
-    ['system VM', { id: 'vm-3', systemvmtype: 'secondarystoragevm' }]
-  ])('requests volumes across project scopes for %s', async (name, resource) => {
-    mockAxios.mockResolvedValue({
-      listvolumesresponse: {
-        volume: [
-          { id: 'data-volume', name: 'Data volume', deviceid: 1 },
-          { id: 'root-volume', name: 'Root volume', deviceid: 0 }
-        ]
-      }
+    ['project instance in Default view', projectVm, null],
+    ['project instance in its project', projectVm, projectVm.projectid],
+    ['project instance in another project', projectVm, 'project-2'],
+    ['account instance in Default view', accountVm, null],
+    ['account instance in another project', accountVm, 'project-2'],
+    ['system VM in Default view', systemVm, null],
+    ['system VM in another project', systemVm, 'project-2']
+  ])('shows volume rows for %s', async (name, resource, selectedProjectId) => {
+    vueProps.$localStorage.get.mockImplementation(key => {
+      return key === CURRENT_PROJECT && selectedProjectId ? { id: selectedProjectId } : null
+    })
+    let interceptor
+    const response = new Promise((resolve, reject) => {
+      interceptor = axios.interceptors.response.use(data => {
+        resolve(data)
+        return data
+      }, error => {
+        reject(error)
+        return Promise.reject(error)
+      })
     })
     const wrapper = common.createFactory(VolumesTab, {
       router,
@@ -87,24 +131,25 @@ describe('Components > View > VolumesTab.vue', () => {
       props: { resource }
     })
 
-    await flushPromises()
+    try {
+      await response
+      await flushPromises()
 
-    expect(mockAxios).toHaveBeenCalledWith({
-      url: '/',
-      method: 'GET',
-      params: {
+      expect(wrapper.findAll('tbody tr[data-row-key]')).toHaveLength(2)
+      expect(requests).toEqual([{
         command: 'listVolumes',
         response: 'json',
-        listall: true,
-        listsystemvms: true,
+        listall: 'true',
+        listsystemvms: 'true',
         projectid: '-1',
         virtualmachineid: resource.id
-      }
-    })
-    expect(wrapper.vm.volumes.map(volume => volume.id)).toEqual(['root-volume', 'data-volume'])
-    expect(wrapper.text()).toContain('Root volume')
-    expect(wrapper.text()).toContain('Data volume')
-
-    wrapper.unmount()
+      }])
+      expect(wrapper.vm.volumes.map(volume => volume.id)).toEqual(['root-volume', 'data-volume'])
+      expect(wrapper.text()).toContain('Root volume')
+      expect(wrapper.text()).toContain('Data volume')
+    } finally {
+      wrapper.unmount()
+      axios.interceptors.response.eject(interceptor)
+    }
   })
 })

--- a/ui/tests/unit/components/view/VolumesTab.spec.js
+++ b/ui/tests/unit/components/view/VolumesTab.spec.js
@@ -17,14 +17,25 @@
 
 import { flushPromises } from '@vue/test-utils'
 
+import mockAxios from '../../../mock/mockAxios'
 import common from '../../../common'
 import VolumesTab from '@/components/view/VolumesTab.vue'
+
+jest.mock('axios', () => mockAxios)
+jest.mock('@/vue-app', () => ({
+  vueProps: {
+    $localStorage: {
+      get: jest.fn(() => null)
+    }
+  }
+}))
 
 const router = common.createMockRouter()
 const i18n = common.createMockI18n('en')
 
 describe('Components > View > VolumesTab.vue', () => {
   beforeEach(() => {
+    jest.clearAllMocks()
     jest.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
@@ -52,6 +63,47 @@ describe('Components > View > VolumesTab.vue', () => {
 
     expect(wrapper.text()).toContain('2.00 GiB')
     expect(wrapper.text()).not.toContain('2.00 GB')
+    expect(mockAxios).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it.each([
+    ['project instance', { id: 'vm-1', projectid: 'project-1' }],
+    ['account instance', { id: 'vm-2' }],
+    ['system VM', { id: 'vm-3', systemvmtype: 'secondarystoragevm' }]
+  ])('requests volumes across project scopes for %s', async (name, resource) => {
+    mockAxios.mockResolvedValue({
+      listvolumesresponse: {
+        volume: [
+          { id: 'data-volume', name: 'Data volume', deviceid: 1 },
+          { id: 'root-volume', name: 'Root volume', deviceid: 0 }
+        ]
+      }
+    })
+    const wrapper = common.createFactory(VolumesTab, {
+      router,
+      i18n,
+      props: { resource }
+    })
+
+    await flushPromises()
+
+    expect(mockAxios).toHaveBeenCalledWith({
+      url: '/',
+      method: 'GET',
+      params: {
+        command: 'listVolumes',
+        response: 'json',
+        listall: true,
+        listsystemvms: true,
+        projectid: '-1',
+        virtualmachineid: resource.id
+      }
+    })
+    expect(wrapper.vm.volumes.map(volume => volume.id)).toEqual(['root-volume', 'data-volume'])
+    expect(wrapper.text()).toContain('Root volume')
+    expect(wrapper.text()).toContain('Data volume')
 
     wrapper.unmount()
   })


### PR DESCRIPTION
### Description

Opening a project instance from Default view shows an empty Volumes tab even though its disks exist. The tab now includes accessible project resources while keeping the instance ID filter, so the disks appear without switching projects.

Fixes: https://github.com/apache/cloudstack/issues/14070

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] Build/CI
- [ ] Test (unit or integration test code)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [ ] Major
- [ ] Minor

#### Bug Severity

- [ ] BLOCKER
- [ ] Critical
- [ ] Major
- [x] Minor
- [ ] Trivial

### Screenshots (if appropriate):

The reproduction checks the rendered table rows; the layout is unchanged.

### How Has This Been Tested?

The committed regression mounts Vue against a local HTTP fixture with CloudStack's project filtering. It exercises the API client, Axios project selection, and rendered rows without replacing those functions.

I also ran the mounted tab against CloudStack 4.22.1.0 with real MySQL and API-created instances on its Simulator hypervisor. The [live reproduction and logs](https://gist.github.com/73c9a09f40ae15eae5f29a5c5957d28b) cover that run.

| # | Scenario | Command | Result |
|---|---|---|---|
| 1 | Project instance in Default view | Command below, before fix | Zero rendered rows |
| 2 | Same component after fix | Same command | Root and data disks |

<details><summary>Raw logs</summary>

From `ui`; the test and its HTTP fixture are both in this diff:

```sh
npm run test:unit -- --runInBand --coverage=false --verbose tests/unit/components/view/VolumesTab.spec.js
```

Before:

```text
    Expected length: 2
    Received length: 0
    Received array:  []
```

After:

```text
    ✓ shows volume rows for project instance in Default view (40ms)
Tests:       8 passed, 8 total
```

</details>

#### How did you try to break this feature and the system with this change?

I also selected a different project and exercised account and system VMs. Regression cases cover disk order and prefetched rows.